### PR TITLE
feat: add call groups browser UI with list and detail pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import UnitDetail from '@/pages/UnitDetail'
 import Settings from '@/pages/Settings'
 import Affiliations from '@/pages/Affiliations'
 import TalkgroupDirectory from '@/pages/TalkgroupDirectory'
+import CallGroups from '@/pages/CallGroups'
+import CallGroupDetail from '@/pages/CallGroupDetail'
 import Admin from '@/pages/Admin'
 import Transcriptions from '@/pages/Transcriptions'
 import TalkgroupAnalytics from '@/pages/TalkgroupAnalytics'
@@ -38,6 +40,8 @@ export default function App() {
         <Route path="/systems/:id" element={<SystemDetail />} />
         <Route path="/affiliations" element={<Affiliations />} />
         <Route path="/directory" element={<TalkgroupDirectory />} />
+        <Route path="/call-groups" element={<CallGroups />} />
+        <Route path="/call-groups/:id" element={<CallGroupDetail />} />
         <Route path="/investigate" element={<Investigate />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/admin" element={<Admin />} />

--- a/src/components/command/GoToMenu.tsx
+++ b/src/components/command/GoToMenu.tsx
@@ -17,6 +17,7 @@ const NAVIGATION_OPTIONS = [
   { key: 'A', label: 'Affiliations', path: '/affiliations' },
   { key: 'E', label: 'Systems', path: '/systems' },
   { key: 'R', label: 'Directory', path: '/directory' },
+  { key: 'G', label: 'Call Groups', path: '/call-groups' },
   { key: 'I', label: 'Investigate', path: '/investigate' },
   { key: 'S', label: 'Settings', path: '/settings' },
   { key: 'X', label: 'Admin', path: '/admin' },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -163,6 +163,20 @@ const navItems = [
     ),
   },
   {
+    label: 'Call Groups',
+    path: '/call-groups',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        <line x1="9" x2="9" y1="11" y2="15" />
+        <line x1="7" x2="11" y1="13" y2="13" />
+      </svg>
+    ),
+  },
+  {
     label: 'Settings',
     path: '/settings',
     icon: (

--- a/src/pages/CallGroupDetail.tsx
+++ b/src/pages/CallGroupDetail.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { getCallGroup } from '@/api/client'
+import type { CallGroup, Call } from '@/api/types'
+import { formatRelativeTime, formatFrequency } from '@/lib/utils'
+import { useAudioStore } from '@/stores/useAudioStore'
+
+export default function CallGroupDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [group, setGroup] = useState<CallGroup | null>(null)
+  const [calls, setCalls] = useState<Call[]>([])
+  const [loading, setLoading] = useState(true)
+  const loadCall = useAudioStore((s) => s.loadCall)
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    getCallGroup(Number(id))
+      .then((res) => {
+        setGroup(res.call_group)
+        setCalls(res.calls || [])
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [id])
+
+  const handlePlay = useCallback((call: Call) => {
+    loadCall(call)
+  }, [loadCall])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 text-muted-foreground">
+        Loading call group...
+      </div>
+    )
+  }
+
+  if (!group) {
+    return (
+      <div className="flex items-center justify-center h-32 text-muted-foreground">
+        Call group not found
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+          <Link to="/call-groups" className="hover:text-primary hover:underline">Call Groups</Link>
+          <span>/</span>
+        </div>
+        <h1 className="text-2xl font-bold">
+          {group.tg_alpha_tag || `TG ${group.tgid}`}
+        </h1>
+        <p className="text-muted-foreground">
+          {group.system_name && <span>{group.system_name} · </span>}
+          {group.call_count != null && <span>{group.call_count} call{group.call_count !== 1 ? 's' : ''} · </span>}
+          {group.start_time && <span>Started {formatRelativeTime(group.start_time)}</span>}
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Group Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+            {group.tgid != null && (
+              <div>
+                <dt className="text-muted-foreground">Talkgroup ID</dt>
+                <dd className="font-mono">{group.tgid}</dd>
+              </div>
+            )}
+            {group.tg_alpha_tag && (
+              <div>
+                <dt className="text-muted-foreground">Alpha Tag</dt>
+                <dd>{group.tg_alpha_tag}</dd>
+              </div>
+            )}
+            {group.tg_description && (
+              <div>
+                <dt className="text-muted-foreground">Description</dt>
+                <dd>{group.tg_description}</dd>
+              </div>
+            )}
+            {group.tg_group && (
+              <div>
+                <dt className="text-muted-foreground">Group</dt>
+                <dd>{group.tg_group}</dd>
+              </div>
+            )}
+            {group.tg_tag && (
+              <div>
+                <dt className="text-muted-foreground">Tag</dt>
+                <dd>{group.tg_tag}</dd>
+              </div>
+            )}
+            {group.duration != null && (
+              <div>
+                <dt className="text-muted-foreground">Duration</dt>
+                <dd>{Math.round(group.duration)}s</dd>
+              </div>
+            )}
+            {group.site_short_name && (
+              <div>
+                <dt className="text-muted-foreground">Site</dt>
+                <dd>{group.site_short_name}</dd>
+              </div>
+            )}
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recordings ({calls.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {calls.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No recordings available</p>
+          ) : (
+            <div className="space-y-2">
+              {calls.map((call) => (
+                <div
+                  key={call.call_id}
+                  className="flex items-center justify-between rounded-lg border border-border/40 px-4 py-2.5"
+                >
+                  <div className="space-y-0.5 min-w-0">
+                    <div className="text-sm font-medium">
+                      #{call.call_id}
+                      {call.emergency && (
+                        <span className="ml-2 text-[10px] text-red-400 font-bold">EMERGENCY</span>
+                      )}
+                      {call.encrypted && (
+                        <span className="ml-2 text-[10px] text-muted-foreground" title="Encrypted">
+                          🔒
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {call.start_time && <span>{formatRelativeTime(call.start_time)}</span>}
+                      {call.duration != null && <span> · {Math.round(call.duration)}s</span>}
+                      {call.freq != null && <span> · {formatFrequency(call.freq)}</span>}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handlePlay(call)}
+                    disabled={!call.audio_url}
+                  >
+                    Play
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/CallGroups.tsx
+++ b/src/pages/CallGroups.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Pagination } from '@/components/ui/pagination'
+import { Input } from '@/components/ui/input'
+import { getCallGroups, getSystems } from '@/api/client'
+import type { CallGroup, System } from '@/api/types'
+import { formatRelativeTime } from '@/lib/utils'
+
+const PAGE_SIZE = 50
+
+export default function CallGroups() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [groups, setGroups] = useState<CallGroup[]>([])
+  const [systems, setSystems] = useState<System[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const systemFilter = searchParams.get('system_id') || ''
+  const searchQuery = searchParams.get('q') || ''
+  const offset = (page - 1) * PAGE_SIZE
+
+  useEffect(() => {
+    getSystems().then((res) => setSystems(res.systems)).catch(console.error)
+  }, [])
+
+  const fetchGroups = useCallback(() => {
+    setLoading(true)
+    getCallGroups({
+      sysid: systemFilter || undefined,
+      limit: PAGE_SIZE,
+      offset,
+    })
+      .then((res) => {
+        setGroups(res.call_groups)
+        setTotalCount(res.total)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [systemFilter, offset])
+
+  useEffect(() => {
+    fetchGroups()
+  }, [fetchGroups])
+
+  const updateParam = useCallback(
+    (key: string, value: string) => {
+      const next = new URLSearchParams(searchParams)
+      if (value) next.set(key, value)
+      else next.delete(key)
+      if (key !== 'page') next.set('page', '1')
+      setSearchParams(next)
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const goToPage = useCallback(
+    (newPage: number) => {
+      const next = new URLSearchParams(searchParams)
+      next.set('page', String(newPage))
+      setSearchParams(next)
+    },
+    [searchParams, setSearchParams]
+  )
+
+  // Client-side keyword filter
+  const filteredGroups = searchQuery
+    ? groups.filter((g) => {
+        const q = searchQuery.toLowerCase()
+        return (
+          g.tg_alpha_tag?.toLowerCase().includes(q) ||
+          g.tg_description?.toLowerCase().includes(q) ||
+          g.tg_tag?.toLowerCase().includes(q) ||
+          g.tg_group?.toLowerCase().includes(q) ||
+          String(g.tgid).includes(q)
+        )
+      })
+    : groups
+
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Call Groups</h1>
+        <p className="text-muted-foreground">
+          Grouped duplicate call recordings from multiple sites
+          {!loading && <span className="ml-2 text-xs">({totalCount} total)</span>}
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap gap-4">
+            <select
+              value={systemFilter}
+              onChange={(e) => updateParam('system_id', e.target.value)}
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="">All Systems</option>
+              {systems.map((s) => (
+                <option key={s.system_id} value={s.sysid}>
+                  {s.name || s.sysid || `System ${s.system_id}`}
+                </option>
+              ))}
+            </select>
+            <Input
+              placeholder="Filter by talkgroup..."
+              value={searchQuery}
+              onChange={(e) => updateParam('q', e.target.value)}
+              className="w-48"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-32 text-muted-foreground">
+          Loading...
+        </div>
+      ) : filteredGroups.length === 0 ? (
+        <div className="flex items-center justify-center h-32 text-muted-foreground">
+          No call groups found
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filteredGroups.map((group) => (
+            <Link
+              key={group.id}
+              to={`/call-groups/${group.id}`}
+              className="block rounded-lg border border-border/40 bg-card/50 px-4 py-3 hover:bg-card transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">
+                      {group.tg_alpha_tag || `TG ${group.tgid}`}
+                    </span>
+                    {group.tg_group && (
+                      <Badge variant="secondary" className="text-[10px]">{group.tg_group}</Badge>
+                    )}
+                    {group.has_transcription && (
+                      <Badge variant="outline" className="text-[10px] text-green-400 border-green-700/40">
+                        TX
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {group.system_name && <span>{group.system_name} · </span>}
+                    {group.call_count != null && <span>{group.call_count} call{group.call_count !== 1 ? 's' : ''} · </span>}
+                    {group.start_time && <span>{formatRelativeTime(group.start_time)}</span>}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground shrink-0">
+                  {group.duration ? `${Math.round(group.duration)}s` : ''}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <Pagination
+          page={page}
+          totalCount={totalCount}
+          pageSize={PAGE_SIZE}
+          onPageChange={goToPage}
+          onPageSizeChange={(size) => updateParam('size', String(size))}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New 'Call Groups' page at /call-groups with system filter, keyword search, and pagination
- New detail page at /call-groups/:id showing group metadata and individual recordings
- Sidebar nav item and GoToMenu entry for keyboard navigation
- Uses existing API endpoints (getCallGroups, getCallGroup)

Fixes #12