### PR TITLE
feat(auth): add explicit auth state machine, remove legacy guest_access handling

### DIFF
--- a/src/api/auth-init.ts
+++ b/src/api/auth-init.ts
@@ -9,30 +9,23 @@ export interface AuthInitResult {
   jwtEnabled: boolean
 }
 
-/**
- * Fetch auth-init and update the auth store with the detected mode.
- * Returns the result, or null if the fetch failed.
- * Safe to call multiple times — skips if authMode is already set.
- */
 export async function detectAuthMode(): Promise<AuthInitResult | null> {
-  // Already detected — return current state
   const current = useAuthStore.getState()
-  if (current.authMode !== null) {
+  if (current.authState === 'open' || current.authState === 'token' || current.authState === 'authenticated') {
     return {
-      mode: current.authMode,
+      mode: current.authMode!,
       readToken: current.readToken,
       jwtEnabled: current.jwtEnabled,
     }
   }
 
-  let mode: AuthMode = 'full'
-  let readToken = ''
-  let jwtEnabled = true
+  useAuthStore.getState().setDetecting()
 
   try {
     const res = await fetch(`${API_BASE}/auth-init`)
     if (!res.ok) {
       console.error(`auth-init returned ${res.status} ${res.statusText}`)
+      useAuthStore.getState().setError(`auth-init returned ${res.status}`)
       return null
     }
 
@@ -41,35 +34,36 @@ export async function detectAuthMode(): Promise<AuthInitResult | null> {
       data = await res.json()
     } catch (parseErr) {
       console.error('auth-init returned OK but body is not valid JSON:', parseErr)
+      useAuthStore.getState().setError('Invalid response from auth-init')
       return null
     }
 
-    if (data && typeof data === 'object') {
-      if (data.mode && VALID_MODES.has(data.mode)) {
-        mode = data.mode
-        readToken = data.read_token || ''
-        jwtEnabled = data.jwt_enabled ?? false
-      } else if (data.mode) {
-        console.warn(`auth-init returned unrecognized mode: "${data.mode}", requiring login`)
-        mode = 'full'
-        jwtEnabled = true
-      } else if ('token' in data) {
-        // Legacy response: { token, guest_access }
-        readToken = data.token || ''
-        if (data.guest_access) {
-          mode = readToken ? 'full' : 'open'
-          jwtEnabled = false
-        } else {
-          mode = 'full'
-          jwtEnabled = true
-        }
-      }
+    if (!data || typeof data !== 'object') {
+      useAuthStore.getState().setError('Invalid auth-init response')
+      return null
     }
+
+    if (data.mode && VALID_MODES.has(data.mode)) {
+      const mode = data.mode as AuthMode
+      const readToken = data.read_token || ''
+      const jwtEnabled = data.jwt_enabled ?? false
+      useAuthStore.getState().setAuthInit(mode, readToken, jwtEnabled)
+      return { mode, readToken, jwtEnabled }
+    }
+
+    if (data.mode) {
+      console.warn(`auth-init returned unrecognized mode: "${data.mode}", requiring login`)
+      useAuthStore.getState().setLoginRequired()
+      return { mode: 'full', readToken: '', jwtEnabled: true }
+    }
+
+    // Fallback: no mode field — assume open
+    const readToken = data.token || ''
+    useAuthStore.getState().setOpen(readToken)
+    return { mode: 'open', readToken, jwtEnabled: false }
   } catch (err) {
     console.error('auth-init fetch failed:', err)
+    useAuthStore.getState().setError('Unable to connect to the API. Check that tr-engine is running.')
     return null
   }
-
-  useAuthStore.getState().setAuthInit(mode, readToken, jwtEnabled)
-  return { mode, readToken, jwtEnabled }
 }

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,87 +1,74 @@
-import { useState, useEffect, type ReactNode } from 'react'
+import { useEffect, useCallback } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { refreshAuth } from '@/api/client'
 import { detectAuthMode } from '@/api/auth-init'
 
 interface RequireAuthProps {
-  children: ReactNode
+  children: React.ReactNode
 }
 
 export function RequireAuth({ children }: RequireAuthProps) {
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const authState = useAuthStore((s) => s.authState)
+  const errorMessage = useAuthStore((s) => s.errorMessage)
   const setAuth = useAuthStore((s) => s.setAuth)
-  const [checking, setChecking] = useState(true)
-  const [authRequired, setAuthRequired] = useState(false)
-  const [authError, setAuthError] = useState(false)
+  const setLoginRequired = useAuthStore((s) => s.setLoginRequired)
+
+  const init = useCallback(async () => {
+    const result = await detectAuthMode()
+    if (!result) return
+
+    if (result.mode === 'full' && result.jwtEnabled) {
+      const refreshResult = await refreshAuth()
+      if (refreshResult) {
+        setAuth(refreshResult.access_token, refreshResult.user)
+      } else {
+        setLoginRequired()
+      }
+    }
+  }, [setAuth, setLoginRequired])
 
   useEffect(() => {
-    if (isAuthenticated) {
-      setChecking(false)
-      return
+    if (authState === 'idle') {
+      init()
     }
+  }, [authState, init])
 
-    let cancelled = false
-
-    async function init() {
-      const result = await detectAuthMode()
-
-      if (cancelled) return
-
-      if (!result) {
-        setAuthError(true)
-        setChecking(false)
-        return
-      }
-
-      // Only full mode with JWT requires login; all other modes skip auth
-      if (result.mode === 'full' && result.jwtEnabled) {
-        const refreshResult = await refreshAuth()
-        if (cancelled) return
-        if (refreshResult) {
-          setAuth(refreshResult.access_token, refreshResult.user)
-        } else {
-          setAuthRequired(true)
-        }
-      }
-
-      setChecking(false)
-    }
-
-    init()
-    return () => { cancelled = true }
-  }, [isAuthenticated, setAuth])
-
-  if (checking) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-muted-foreground">Loading...</div>
-      </div>
-    )
-  }
-
-  if (authError) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center space-y-2">
-          <div className="text-destructive font-medium">Unable to connect to the API</div>
-          <div className="text-sm text-muted-foreground">
-            Could not determine authentication mode. Check that tr-engine is running.
-          </div>
-          <button
-            onClick={() => window.location.reload()}
-            className="text-sm text-primary underline hover:no-underline"
-          >
-            Retry
-          </button>
+  switch (authState) {
+    case 'idle':
+    case 'detecting':
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background">
+          <div className="text-muted-foreground">Loading...</div>
         </div>
-      </div>
-    )
-  }
+      )
 
-  if (authRequired && !isAuthenticated) {
-    return <Navigate to="/login" replace />
-  }
+    case 'open':
+    case 'token':
+      return <>{children}</>
 
-  return <>{children}</>
+    case 'authenticated':
+      return <>{children}</>
+
+    case 'login-required':
+      return <Navigate to="/login" replace />
+
+    case 'error':
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background">
+          <div className="text-center space-y-2">
+            <div className="text-destructive font-medium">Unable to connect to the API</div>
+            <div className="text-sm text-muted-foreground">
+              {errorMessage || 'Could not determine authentication mode. Check that tr-engine is running.'}
+            </div>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-sm text-primary underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      )
+  }
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,13 +5,11 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { login, setupFirstUser, checkNeedsSetup } from '@/api/client'
-import { detectAuthMode } from '@/api/auth-init'
 
 export default function Login() {
   const navigate = useNavigate()
   const setAuth = useAuthStore((s) => s.setAuth)
-  const authMode = useAuthStore((s) => s.authMode)
-  const jwtEnabled = useAuthStore((s) => s.jwtEnabled)
+  const authState = useAuthStore((s) => s.authState)
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -19,34 +17,17 @@ export default function Login() {
   const [loading, setLoading] = useState(false)
   const [setupMode, setSetupMode] = useState(false)
   const [checkingSetup, setCheckingSetup] = useState(true)
-  const [detectingAuth, setDetectingAuth] = useState(authMode === null)
 
-  const needsLogin = authMode === 'full' && jwtEnabled
-
-  // If navigated directly to /login, detect auth mode ourselves
+  // If navigated directly to /login but auth state already resolved to open/token
   useEffect(() => {
-    if (authMode !== null) {
-      setDetectingAuth(false)
-      return
-    }
-    detectAuthMode().then((result) => {
-      setDetectingAuth(false)
-      if (!result) {
-        setError('Unable to connect to the API. Check that tr-engine is running.')
-        setCheckingSetup(false)
-      }
-    })
-  }, [authMode])
-
-  // Once auth mode is known, check if login is needed and if setup is required
-  useEffect(() => {
-    if (authMode === null) return
-
-    // No JWT login available — redirect to home
-    if (!needsLogin) {
+    if (authState === 'open' || authState === 'token' || authState === 'authenticated') {
       navigate('/', { replace: true })
-      return
     }
+  }, [authState, navigate])
+
+  // Once we know login is needed, check if setup is required
+  useEffect(() => {
+    if (authState !== 'login-required') return
 
     checkNeedsSetup().then((needs) => {
       setSetupMode(needs)
@@ -55,10 +36,9 @@ export default function Login() {
       setError('Could not determine setup status. Check your connection and reload.')
       setCheckingSetup(false)
     })
-  }, [authMode, needsLogin, navigate])
+  }, [authState])
 
-  // Show loading while auth mode is being detected
-  if (detectingAuth) {
+  if (authState === 'idle' || authState === 'detecting') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-muted-foreground">Loading...</div>
@@ -108,7 +88,6 @@ export default function Login() {
       navigate('/', { replace: true })
     } catch (err: any) {
       if (err?.status === 409) {
-        // Setup already completed — switch to login mode
         setSetupMode(false)
         setError('Setup already completed. Please sign in.')
         setPassword('')

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -9,36 +9,53 @@ export interface AuthUser {
 
 export type AuthMode = 'open' | 'token' | 'full'
 
-interface AuthState {
-  // Auth mode from auth-init endpoint
+/**
+ * Auth state machine:
+ *   idle → detecting → open | token | login-required | authenticated | error
+ *   login-required → authenticated (on login)
+ *   authenticated → login-required (on logout / session expiry)
+ *   error → detecting (on retry)
+ */
+export type AuthState =
+  | 'idle'
+  | 'detecting'
+  | 'open'
+  | 'token'
+  | 'login-required'
+  | 'authenticated'
+  | 'error'
+
+interface AuthStateStore {
+  authState: AuthState
   authMode: AuthMode | null
   jwtEnabled: boolean
   readToken: string
-
-  // JWT auth
   accessToken: string
   user: AuthUser | null
   isAuthenticated: boolean
-
-  // Legacy write token (backward compat / token mode)
   writeToken: string
+  errorMessage: string
 
-  // Actions
+  setDetecting: () => void
+  setOpen: (readToken: string) => void
+  setToken: (readToken: string) => void
+  setLoginRequired: () => void
+  setAuthenticated: (accessToken: string, user: AuthUser) => void
   setAuthInit: (mode: AuthMode, readToken: string, jwtEnabled: boolean) => void
   setAuth: (accessToken: string, user: AuthUser) => void
   clearAuth: () => void
+  setError: (message: string) => void
   setAccessToken: (token: string) => void
   setWriteToken: (token: string) => void
   clearWriteToken: () => void
-
-  // Role helpers
   isAdmin: () => boolean
   canWrite: () => boolean
 }
 
-export const useAuthStore = create<AuthState>()(
+export const useAuthStore = create<AuthStateStore>()(
   persist(
     (set, get) => ({
+      authState: 'idle',
       authMode: null,
       jwtEnabled: false,
       readToken: '',
@@ -46,16 +63,52 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       isAuthenticated: false,
       writeToken: '',
+      errorMessage: '',
 
-      setAuthInit: (mode, readToken, jwtEnabled) =>
-        set({ authMode: mode, readToken, jwtEnabled }),
+      setDetecting: () => set({ authState: 'detecting' }),
+
+      setOpen: (readToken) =>
+        set({ authState: 'open', authMode: 'open', readToken, jwtEnabled: false }),
+
+      setToken: (readToken) =>
+        set({ authState: 'token', authMode: 'token', readToken, jwtEnabled: false }),
+
+      setLoginRequired: () =>
+        set({ authState: 'login-required', authMode: 'full', jwtEnabled: true, readToken: '' }),
+
+      setAuthenticated: (accessToken, user) =>
+        set({
+          authState: 'authenticated',
+          authMode: 'full',
+          jwtEnabled: true,
+          accessToken,
+          user,
+          isAuthenticated: true,
+        }),
+
+      setAuthInit: (mode, readToken, jwtEnabled) => {
+        if (mode === 'open') {
+          set({ authState: 'open', authMode: mode, readToken, jwtEnabled })
+        } else if (mode === 'token') {
+          set({ authState: 'token', authMode: mode, readToken, jwtEnabled })
+        } else if (mode === 'full' && jwtEnabled) {
+          set({ authState: 'login-required', authMode: mode, readToken, jwtEnabled })
+        } else {
+          set({ authState: 'open', authMode: mode, readToken, jwtEnabled })
+        }
+      },
 
       setAuth: (accessToken, user) =>
-        set({ accessToken, user, isAuthenticated: true }),
+        set({ accessToken, user, isAuthenticated: true, authState: 'authenticated' }),
 
-      // Full reset: clears JWT session and auth-init state, forcing re-detection
       clearAuth: () =>
-        set({ accessToken: '', user: null, isAuthenticated: false, authMode: null, readToken: '', jwtEnabled: false }),
+        set({
+          accessToken: '', user: null, isAuthenticated: false,
+          authMode: null, readToken: '', jwtEnabled: false,
+          authState: 'idle', errorMessage: '',
+        }),
+
+      setError: (message) => set({ authState: 'error', errorMessage: message }),
 
       setAccessToken: (token) => set({ accessToken: token }),
 
@@ -71,21 +124,16 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'tr-dashboard-auth',
-      // Only persist writeToken. Access token lives in memory only
-      // (restored via refreshAuth on page load). User is also memory-only
-      // to avoid a stale-role window where isAdmin()/canWrite() return
-      // truthy before the refresh validates the session.
       partialize: (state) => ({
         writeToken: state.writeToken,
       }),
-      // Migrate from old store shape — discard any persisted auth state
       migrate: (persisted: any, version: number) => {
         if (version === 0 && persisted && typeof persisted === 'object') {
           return {
             writeToken: persisted.writeToken || '',
           }
         }
-        return persisted as AuthState
+        return persisted as AuthStateStore
       },
       version: 2,
     }


### PR DESCRIPTION
## Summary
- Replaced implicit auth mode logic with an explicit state machine: `idle → detecting → open | token | login-required | authenticated | error`
- Removed legacy `guest_access` band-aid from auth-init parser
- Clean state transitions via dedicated store actions (`setOpen`, `setToken`, `setLoginRequired`, `setAuthenticated`, `setError`)
- RequireAuth uses switch on `authState` for clear, exhaustive state handling
- Error state surfaces specific error messages from auth-init failures
- Login page reads `authState` directly instead of re-deriving from `authMode`/`jwtEnabled`

Fixes #7