### PR TITLE
fix: display encrypted call percentage on talkgroup pages

### DIFF
--- a/src/pages/TalkgroupDetail.tsx
+++ b/src/pages/TalkgroupDetail.tsx
@@ -3,8 +3,8 @@ import { useParams, Link } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { getTalkgroup, getTalkgroupCalls, updateTalkgroup, getCachedSystemType } from '@/api/client'
-import type { Talkgroup, Call, TalkgroupPatch } from '@/api/types'
+import { getTalkgroup, getTalkgroupCalls, updateTalkgroup, getEncryptionStats, getCachedSystemType } from '@/api/client'
+import type { Talkgroup, Call, TalkgroupPatch, TalkgroupEncryptionStat } from '@/api/types'
 import { useTranscriptionCache } from '@/stores/useTranscriptionCache'
 import { useFilterStore } from '@/stores/useFilterStore'
 import { useMonitorStore } from '@/stores/useMonitorStore'
@@ -21,6 +21,7 @@ export default function TalkgroupDetail() {
   const [calls, setCalls] = useState<Call[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [encryptionStat, setEncryptionStat] = useState<TalkgroupEncryptionStat | null>(null)
   const [unitSort, setUnitSort] = useState<'alpha_tag' | 'unit_id' | 'count'>('count')
   const [unitSortDir, setUnitSortDir] = useState<'asc' | 'desc'>('desc')
 
@@ -69,6 +70,14 @@ export default function TalkgroupDetail() {
             fetchTranscription(call.call_id)
           }
         }
+
+        // Fetch encryption stats for this talkgroup
+        getEncryptionStats({ hours: 168 }).then((res) => {
+          const stat = res.stats.find(
+            (s) => s.system_id === tgRes.system_id && s.tgid === tgRes.tgid
+          )
+          if (stat) setEncryptionStat(stat)
+        }).catch(() => {})
       })
       .catch((err) => {
         console.error(err)
@@ -416,6 +425,17 @@ export default function TalkgroupDetail() {
             <span className="text-muted-foreground">Units </span>
             <span className="font-bold tabular-nums">{talkgroup.unit_count?.toLocaleString() ?? '—'}</span>
           </div>
+          {encryptionStat && encryptionStat.total_count != null && encryptionStat.total_count > 0 && (
+            <div>
+              <span className="text-muted-foreground">Encrypted </span>
+              <span className="font-bold tabular-nums text-amber-400">
+                {Math.round(encryptionStat.encrypted_pct ?? 0)}%
+              </span>
+              <span className="text-xs text-muted-foreground ml-1">
+                ({encryptionStat.encrypted_count}/{encryptionStat.total_count})
+              </span>
+            </div>
+          )}
           <div className="ml-auto flex items-center gap-4 text-xs text-muted-foreground">
             {talkgroup.system_name && (
               <span>

--- a/src/pages/Talkgroups.tsx
+++ b/src/pages/Talkgroups.tsx
@@ -3,9 +3,9 @@ import { useSearchParams, Link } from 'react-router-dom'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Pagination } from '@/components/ui/pagination'
-import { getTalkgroups, getSystems } from '@/api/client'
+import { getTalkgroups, getSystems, getEncryptionStats } from '@/api/client'
 import { getSystemTypeLabel } from '@/lib/utils'
-import type { Talkgroup, System } from '@/api/types'
+import type { Talkgroup, System, TalkgroupEncryptionStat } from '@/api/types'
 import { useFilterStore } from '@/stores/useFilterStore'
 import { useMonitorStore } from '@/stores/useMonitorStore'
 import { useRealtimeStore } from '@/stores/useRealtimeStore'
@@ -22,6 +22,7 @@ export default function Talkgroups() {
   const [systems, setSystems] = useState<System[]>([])
   const [availableGroups, setAvailableGroups] = useState<string[]>([])
   const [availableTags, setAvailableTags] = useState<string[]>([])
+  const [encryptionStats, setEncryptionStats] = useState<Map<string, TalkgroupEncryptionStat>>(new Map())
   const [loading, setLoading] = useState(true)
   const [openOverrideMenu, setOpenOverrideMenu] = useState<string | null>(null)
   const overrideMenuRef = useRef<HTMLDivElement>(null)
@@ -119,6 +120,17 @@ export default function Talkgroups() {
         }
         setAvailableGroups(Array.from(groups).sort())
         setAvailableTags(Array.from(tags).sort())
+
+        // Fetch encryption stats for all talkgroups
+        getEncryptionStats().then((res) => {
+          const map = new Map<string, TalkgroupEncryptionStat>()
+          for (const stat of res.stats) {
+            if (stat.system_id != null && stat.tgid != null) {
+              map.set(talkgroupKey(stat.system_id, stat.tgid), stat)
+            }
+          }
+          setEncryptionStats(map)
+        }).catch(() => {})
       })
       .catch(console.error)
       .finally(() => setLoading(false))
@@ -494,6 +506,17 @@ export default function Talkgroups() {
                       <span><span className="text-foreground">{tg.calls_1h ?? 0}</span>/1h</span>
                       <span><span className="text-foreground">{tg.calls_24h ?? 0}</span>/24h</span>
                       <span><span className="text-foreground">{tg.unit_count ?? 0}</span>u</span>
+                      {(() => {
+                        const es = encryptionStats.get(talkgroupKey(tg.system_id, tg.tgid))
+                        if (es && es.total_count && es.total_count > 0 && (es.encrypted_pct ?? 0) > 0) {
+                          return (
+                            <span className="text-amber-400/80">
+                              {Math.round(es.encrypted_pct!)}% enc
+                            </span>
+                          )
+                        }
+                        return null
+                      })()}
                       <span className="text-muted-foreground/60">{formatRelativeTime(tg.last_seen || '')}</span>
                       {hasActiveCall && (
                         <span className="shrink-0 px-1 py-0.5 text-[10px] font-bold bg-live text-white rounded ml-auto">


### PR DESCRIPTION
## Summary
- The `getEncryptionStats()` endpoint existed but was never called from any page
- Talkgroups list page now fetches encryption stats and displays `N% enc` on cards with encrypted calls
- TalkgroupDetail page shows encrypted percentage and count in the stats section
- Percentage shown in amber to differentiate from regular stats

Fixes #15