### PR TITLE
feat: add switchable theme system with dark, amber, high-contrast, and light modes

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from '@/components/command/CommandPalette'
 import { GoToMenu } from '@/components/command/GoToMenu'
 import { initializeRealtimeConnection } from '@/stores/useRealtimeStore'
 import { useUpdateStore } from '@/stores/useUpdateStore'
+import { useThemeStore } from '@/stores/useThemeStore'
 import { getHealth } from '@/api/client'
 import { KEYBOARD_SHORTCUTS } from '@/lib/constants'
 import { usePageTitle } from '@/hooks/usePageTitle'
@@ -28,6 +29,13 @@ export function MainLayout() {
   usePageTitle()
   useFaviconStatus()
   useEmergencyNotifications()
+
+  // Apply persisted theme on mount
+  const theme = useThemeStore((s) => s.theme)
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
 
   // Initialize SSE connection and check for updates
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,118 @@
   }
 }
 
+/* =============================================================================
+   Theme System
+   Each theme overrides CSS custom properties on [data-theme="..."].
+   ============================================================================= */
+
+[data-theme="dark"] {
+  --color-background: #0f172a;
+  --color-foreground: #f8fafc;
+  --color-card: #1e293b;
+  --color-card-foreground: #f8fafc;
+  --color-popover: #1e293b;
+  --color-popover-foreground: #f8fafc;
+  --color-primary: #f59e0b;
+  --color-primary-foreground: #1e293b;
+  --color-secondary: #334155;
+  --color-secondary-foreground: #f8fafc;
+  --color-muted: #334155;
+  --color-muted-foreground: #94a3b8;
+  --color-accent: #334155;
+  --color-accent-foreground: #f8fafc;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #f8fafc;
+  --color-border: #334155;
+  --color-input: #334155;
+  --color-ring: #f59e0b;
+  --color-success: #22c55e;
+  --color-warning: #f97316;
+  --color-info: #3b82f6;
+  --color-live: #f43f5e;
+}
+
+/* Amber / scanner-inspired warm tones */
+[data-theme="amber"] {
+  --color-background: #1a1500;
+  --color-foreground: #fef3c7;
+  --color-card: #2a2300;
+  --color-card-foreground: #fef3c7;
+  --color-popover: #2a2300;
+  --color-popover-foreground: #fef3c7;
+  --color-primary: #f59e0b;
+  --color-primary-foreground: #1a1500;
+  --color-secondary: #3d3400;
+  --color-secondary-foreground: #fef3c7;
+  --color-muted: #3d3400;
+  --color-muted-foreground: #a88f3c;
+  --color-accent: #3d3400;
+  --color-accent-foreground: #fef3c7;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #fef3c7;
+  --color-border: #4a3f00;
+  --color-input: #3d3400;
+  --color-ring: #f59e0b;
+  --color-success: #4ade80;
+  --color-warning: #fb923c;
+  --color-info: #60a5fa;
+  --color-live: #fb7185;
+}
+
+/* High contrast for control room */
+[data-theme="high-contrast"] {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-card: #1a1a1a;
+  --color-card-foreground: #ffffff;
+  --color-popover: #1a1a1a;
+  --color-popover-foreground: #ffffff;
+  --color-primary: #f59e0b;
+  --color-primary-foreground: #000000;
+  --color-secondary: #333333;
+  --color-secondary-foreground: #ffffff;
+  --color-muted: #333333;
+  --color-muted-foreground: #cccccc;
+  --color-accent: #333333;
+  --color-accent-foreground: #ffffff;
+  --color-destructive: #ff3333;
+  --color-destructive-foreground: #ffffff;
+  --color-border: #555555;
+  --color-input: #333333;
+  --color-ring: #f59e0b;
+  --color-success: #33ff33;
+  --color-warning: #ff8800;
+  --color-info: #3399ff;
+  --color-live: #ff5555;
+}
+
+/* Light mode */
+[data-theme="light"] {
+  --color-background: #f8fafc;
+  --color-foreground: #0f172a;
+  --color-card: #ffffff;
+  --color-card-foreground: #0f172a;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #0f172a;
+  --color-primary: #d97706;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #e2e8f0;
+  --color-secondary-foreground: #0f172a;
+  --color-muted: #e2e8f0;
+  --color-muted-foreground: #64748b;
+  --color-accent: #e2e8f0;
+  --color-accent-foreground: #0f172a;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
+  --color-border: #cbd5e1;
+  --color-input: #e2e8f0;
+  --color-ring: #d97706;
+  --color-success: #16a34a;
+  --color-warning: #ea580c;
+  --color-info: #2563eb;
+  --color-live: #e11d48;
+}
+
 @layer components {
   /* Subtle top-highlight gradient + refined shadow for all cards */
   .card-glass {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import { useAudioStore } from '@/stores/useAudioStore'
 import { useTalkgroupColors, ColorRule, RuleMode } from '@/stores/useTalkgroupColors'
 import { useSignalThresholds, type SignalThresholds } from '@/stores/useSignalThresholds'
 import { useUpdateStore } from '@/stores/useUpdateStore'
+import { useThemeStore, type ThemeId } from '@/stores/useThemeStore'
 import { APP_VERSION } from '@/version'
 import { getSSEManager } from '@/api/eventsource'
 import { Plus, Trash2, RotateCcw } from 'lucide-react'
@@ -36,6 +37,10 @@ export default function Settings() {
   const setAutoPlay = useAudioStore((s) => s.setAutoPlay)
   const volume = useAudioStore((s) => s.volume)
   const setVolume = useAudioStore((s) => s.setVolume)
+
+  // Theme
+  const theme = useThemeStore((s) => s.theme)
+  const setTheme = useThemeStore((s) => s.setTheme)
 
   // Signal quality thresholds
   const signalThresholds = useSignalThresholds()
@@ -315,6 +320,35 @@ export default function Settings() {
             >
               {unitIdHex ? 'Hex' : 'Decimal'}
             </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Theme */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Theme</CardTitle>
+          <CardDescription>Choose your color scheme</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {([
+              { id: 'dark' as ThemeId, label: 'Dark', desc: 'Default dark theme' },
+              { id: 'amber' as ThemeId, label: 'Amber', desc: 'Scanner-inspired warm tones' },
+              { id: 'high-contrast' as ThemeId, label: 'High Contrast', desc: 'Control room visibility' },
+              { id: 'light' as ThemeId, label: 'Light', desc: 'Daytime mode' },
+            ]).map((t) => (
+              <Button
+                key={t.id}
+                variant={theme === t.id ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setTheme(t.id)}
+                className="flex-col items-start gap-0.5 h-auto py-2 px-3"
+              >
+                <span>{t.label}</span>
+                <span className="text-[10px] font-normal opacity-70">{t.desc}</span>
+              </Button>
+            ))}
           </div>
         </CardContent>
       </Card>

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type ThemeId = 'dark' | 'amber' | 'high-contrast' | 'light'
+
+interface ThemeState {
+  theme: ThemeId
+  setTheme: (theme: ThemeId) => void
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'dark',
+      setTheme: (theme) => {
+        set({ theme })
+        document.documentElement.setAttribute('data-theme', theme)
+      },
+    }),
+    {
+      name: 'tr-dashboard-theme',
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- Four themes: Dark (default), Amber (scanner-inspired warm tones), High-Contrast (control room), Light (daytime)
- CSS custom property override approach: each theme is a `[data-theme="..."]` selector overriding color variables
- Theme persisted to localStorage via Zustand persist
- Theme selector added to Settings page with labeled buttons and descriptions
- Initial theme applied from store on MainLayout mount

Fixes #11