### PR TITLE
feat: add alerting and browser notification rules engine

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -13,6 +13,7 @@ import { KEYBOARD_SHORTCUTS } from '@/lib/constants'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useFaviconStatus } from '@/hooks/useFaviconStatus'
 import { useEmergencyNotifications } from '@/hooks/useEmergencyNotifications'
+import { useAlertEngine } from '@/hooks/useAlertEngine'
 import { PWAUpdateBanner } from './PWAUpdateBanner'
 import { OfflineBanner } from './OfflineBanner'
 
@@ -28,6 +29,7 @@ export function MainLayout() {
   usePageTitle()
   useFaviconStatus()
   useEmergencyNotifications()
+  useAlertEngine()
 
   // Initialize SSE connection and check for updates
   useEffect(() => {

--- a/src/hooks/useAlertEngine.ts
+++ b/src/hooks/useAlertEngine.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react'
+import { useRealtimeStore } from '@/stores/useRealtimeStore'
+import { useAlertStore, type AlertRule } from '@/stores/useAlertStore'
+
+const cooldowns = new Map<string, number>()
+
+function isOnCooldown(ruleId: string, cooldownMs: number): boolean {
+  const until = cooldowns.get(ruleId)
+  if (until && Date.now() < until) return true
+  cooldowns.set(ruleId, Date.now() + cooldownMs)
+  return false
+}
+
+function notify(rule: AlertRule, message: string) {
+  if (typeof Notification === 'undefined') return
+  if (Notification.permission === 'granted') {
+    new Notification(rule.label, {
+      body: message,
+      tag: `alert-${rule.id}-${Date.now()}`,
+      icon: '/pwa-192x192.png',
+    })
+  }
+}
+
+function evaluateRule(rule: AlertRule): string | null {
+  const { activeCalls } = useRealtimeStore.getState()
+
+  switch (rule.trigger) {
+    case 'keyword': {
+      const q = rule.value.toLowerCase()
+      for (const call of activeCalls.values()) {
+        if (call.tg_alpha_tag?.toLowerCase().includes(q) ||
+            call.tg_description?.toLowerCase().includes(q)) {
+          return `${call.tg_alpha_tag || `TG ${call.tgid}`} — ${call.system_name || ''}`
+        }
+      }
+      return null
+    }
+
+    case 'talkgroup': {
+      const parts = rule.value.split(':')
+      const systemId = parts.length > 1 ? Number(parts[0]) : undefined
+      const tgid = Number(parts[parts.length - 1])
+      if (isNaN(tgid)) return null
+      for (const call of activeCalls.values()) {
+        if ((!systemId || call.system_id === systemId) && call.tgid === tgid) {
+          return `${call.tg_alpha_tag || `TG ${tgid}`} is active`
+        }
+      }
+      return null
+    }
+
+    case 'unit': {
+      const unitId = Number(rule.value)
+      if (isNaN(unitId)) return null
+      for (const call of activeCalls.values()) {
+        if (call.units?.some((u) => u.unit_id === unitId)) {
+          return `Unit ${unitId} active on ${call.tg_alpha_tag || `TG ${call.tgid}`}`
+        }
+      }
+      return null
+    }
+
+    case 'emergency': {
+      for (const call of activeCalls.values()) {
+        if (call.emergency) {
+          return `Emergency: ${call.tg_alpha_tag || `TG ${call.tgid}`}`
+        }
+      }
+      return null
+    }
+  }
+
+  return null
+}
+
+export function useAlertEngine() {
+  const rules = useAlertStore((s) => s.rules)
+  const addEvent = useAlertStore((s) => s.addEvent)
+  const activeCalls = useRealtimeStore((s) => s.activeCalls)
+  const unitEvents = useRealtimeStore((s) => s.unitEvents)
+  const callCountRef = useRef(activeCalls.size)
+  const unitCountRef = useRef(unitEvents.length)
+
+  useEffect(() => {
+    if (rules.length === 0) return
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      Notification.requestPermission()
+    }
+
+    const enabledRules = rules.filter((r) => r.enabled)
+    if (enabledRules.length === 0) return
+
+    // Only fire if new data arrived
+    if (activeCalls.size === callCountRef.current && unitEvents.length === unitCountRef.current) return
+    callCountRef.current = activeCalls.size
+    unitCountRef.current = unitEvents.length
+
+    // Request notification permissions lazily
+    for (const rule of enabledRules) {
+      if (isOnCooldown(rule.id, rule.cooldownMs)) continue
+      const message = evaluateRule(rule)
+      if (message) {
+        addEvent({ ruleId: rule.id, label: rule.label, message })
+        notify(rule, message)
+      }
+    }
+  }, [rules, activeCalls, unitEvents, addEvent])
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,9 +11,10 @@ import { useAudioStore } from '@/stores/useAudioStore'
 import { useTalkgroupColors, ColorRule, RuleMode } from '@/stores/useTalkgroupColors'
 import { useSignalThresholds, type SignalThresholds } from '@/stores/useSignalThresholds'
 import { useUpdateStore } from '@/stores/useUpdateStore'
+import { useAlertStore, type AlertRule, type AlertTriggerType } from '@/stores/useAlertStore'
 import { APP_VERSION } from '@/version'
 import { getSSEManager } from '@/api/eventsource'
-import { Plus, Trash2, RotateCcw } from 'lucide-react'
+import { Plus, Trash2, RotateCcw, Bell } from 'lucide-react'
 import { ColorPicker, getHexFromTailwind } from '@/components/ui/color-picker'
 import { parseTalkgroupKey, isNewerVersion } from '@/lib/utils'
 
@@ -41,6 +42,14 @@ export default function Settings() {
   const signalThresholds = useSignalThresholds()
   const setThreshold = useSignalThresholds((s) => s.setThreshold)
   const resetSignalThresholds = useSignalThresholds((s) => s.resetToDefaults)
+
+  // Alert rules
+  const alertRules = useAlertStore((s) => s.rules)
+  const alertHistory = useAlertStore((s) => s.history)
+  const addAlertRule = useAlertStore((s) => s.addRule)
+  const updateAlertRule = useAlertStore((s) => s.updateRule)
+  const removeAlertRule = useAlertStore((s) => s.removeRule)
+  const clearAlertHistory = useAlertStore((s) => s.clearHistory)
 
   // Update check
   const updateCheckEnabled = useUpdateStore((s) => s.updateCheckEnabled)
@@ -753,6 +762,85 @@ export default function Settings() {
         </CardContent>
       </Card>
 
+      {/* Alert Rules */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Alert Rules</CardTitle>
+              <CardDescription>Browser notifications for radio activity</CardDescription>
+            </div>
+            <Bell className="h-5 w-5 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {alertRules.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No alert rules configured.</p>
+          ) : (
+            <div className="space-y-2">
+              {alertRules.map((rule) => (
+                <div key={rule.id} className="flex items-center justify-between rounded-lg border px-3 py-2">
+                  <div className="space-y-0.5 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">{rule.label}</span>
+                      <Badge variant="outline" className="text-[10px]">{rule.trigger}</Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground truncate">{rule.value}</p>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant={rule.enabled ? 'default' : 'outline'}
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => updateAlertRule(rule.id, { enabled: !rule.enabled })}
+                    >
+                      {rule.enabled ? 'On' : 'Off'}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => removeAlertRule(rule.id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <Separator />
+          <AlertRuleForm onAdd={addAlertRule} />
+        </CardContent>
+      </Card>
+
+      {/* Alert History */}
+      {alertHistory.length > 0 && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>Alert History</CardTitle>
+              <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={clearAlertHistory}>
+                Clear
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-1 max-h-64 overflow-y-auto">
+              {alertHistory.map((event, i) => (
+                <div key={`${event.timestamp}-${i}`} className="flex items-start gap-2 text-sm py-1 border-b border-border/30 last:border-0">
+                  <span className="text-[10px] text-muted-foreground shrink-0 mt-0.5 font-mono">
+                    {new Date(event.timestamp).toLocaleTimeString()}
+                  </span>
+                  <span className="font-medium text-xs shrink-0 text-primary">{event.label}</span>
+                  <span className="text-xs text-muted-foreground">{event.message}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* About */}
       <Card>
         <CardHeader>
@@ -771,6 +859,77 @@ export default function Settings() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+function AlertRuleForm({ onAdd }: { onAdd: (rule: Omit<AlertRule, 'id'>) => void }) {
+  const [label, setLabel] = useState('')
+  const [trigger, setTrigger] = useState<AlertTriggerType>('keyword')
+  const [value, setValue] = useState('')
+  const [cooldownMs, setCooldownMs] = useState(60000)
+
+  const handleSubmit = () => {
+    if (!label.trim() || !value.trim()) return
+    onAdd({
+      label: label.trim(),
+      enabled: true,
+      trigger,
+      value: value.trim(),
+      cooldownMs,
+    })
+    setLabel('')
+    setValue('')
+  }
+
+  const placeholderMap: Record<AlertTriggerType, string> = {
+    keyword: 'e.g. "fire" or "OSP"',
+    talkgroup: 'e.g. "9178" or "1:9178"',
+    unit: 'e.g. "943001"',
+    emergency: '(no value needed)',
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">Add Rule</p>
+      <div className="flex flex-wrap gap-2">
+        <Input
+          placeholder="Label"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="w-28"
+        />
+        <select
+          value={trigger}
+          onChange={(e) => setTrigger(e.target.value as AlertTriggerType)}
+          className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+        >
+          <option value="keyword">Keyword</option>
+          <option value="talkgroup">Talkgroup</option>
+          <option value="unit">Unit</option>
+          <option value="emergency">Emergency</option>
+        </select>
+        <Input
+          placeholder={placeholderMap[trigger]}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="w-40"
+          disabled={trigger === 'emergency'}
+        />
+        <select
+          value={cooldownMs}
+          onChange={(e) => setCooldownMs(Number(e.target.value))}
+          className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+        >
+          <option value={0}>No cooldown</option>
+          <option value={30000}>30s cooldown</option>
+          <option value={60000}>1m cooldown</option>
+          <option value={300000}>5m cooldown</option>
+        </select>
+        <Button size="sm" onClick={handleSubmit} disabled={!label.trim() || (!value.trim() && trigger !== 'emergency')}>
+          <Plus className="h-4 w-4 mr-1" /> Add
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/stores/useAlertStore.ts
+++ b/src/stores/useAlertStore.ts
@@ -1,0 +1,82 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type AlertTriggerType = 'keyword' | 'talkgroup' | 'unit' | 'emergency'
+
+export interface AlertRule {
+  id: string
+  label: string
+  enabled: boolean
+  trigger: AlertTriggerType
+  value: string
+  cooldownMs: number
+}
+
+export interface AlertEvent {
+  ruleId: string
+  label: string
+  message: string
+  timestamp: number
+}
+
+interface AlertState {
+  rules: AlertRule[]
+  history: AlertEvent[]
+  addRule: (rule: Omit<AlertRule, 'id'>) => void
+  updateRule: (id: string, patch: Partial<AlertRule>) => void
+  removeRule: (id: string) => void
+  moveRule: (fromIndex: number, toIndex: number) => void
+  addEvent: (event: Omit<AlertEvent, 'timestamp'>) => void
+  clearHistory: () => void
+}
+
+let nextId = 1
+function genId(): string {
+  return `alert-${nextId++}`
+}
+
+export const useAlertStore = create<AlertState>()(
+  persist(
+    (set) => ({
+      rules: [],
+      history: [],
+
+      addRule: (rule) =>
+        set((state) => ({
+          rules: [...state.rules, { ...rule, id: genId() }],
+        })),
+
+      updateRule: (id, patch) =>
+        set((state) => ({
+          rules: state.rules.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+        })),
+
+      removeRule: (id) =>
+        set((state) => ({
+          rules: state.rules.filter((r) => r.id !== id),
+        })),
+
+      moveRule: (fromIndex, toIndex) =>
+        set((state) => {
+          const rules = [...state.rules]
+          const [moved] = rules.splice(fromIndex, 1)
+          rules.splice(toIndex, 0, moved)
+          return { rules }
+        }),
+
+      addEvent: (event) =>
+        set((state) => ({
+          history: [
+            { ...event, timestamp: Date.now() },
+            ...state.history,
+          ].slice(0, 200),
+        })),
+
+      clearHistory: () => set({ history: [] }),
+    }),
+    {
+      name: 'tr-dashboard-alerts',
+      version: 1,
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- User-defined alert rules evaluated against the SSE event stream in real-time
- Four trigger types: keyword match, talkgroup watch, unit watch, emergency
- Configurable cooldown per rule (30s, 1m, 5m, or none) to prevent alert storms
- Browser push notifications with rule label and context message
- Alert history with timestamps (last 200 events, persisted in localStorage)
- Full management UI in Settings: add/edit/remove/enable/disable rules
- Alert engine hook runs in MainLayout, lazy-requests notification permissions

Fixes #10