### PR TITLE
feat: UI polish pass — card hover animations, scrollbar styling, page transitions

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -158,7 +158,7 @@ export function MainLayout() {
         )}
 
         <main className="flex flex-1 flex-col overflow-hidden">
-          <div className="flex-1 overflow-auto p-2 md:p-4">
+          <div className="flex-1 overflow-auto p-2 md:p-4 scrollbar-thin page-enter">
             <Outlet />
           </div>
           <div className="safe-area-bottom">

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,29 @@
     animation-delay: calc(var(--i, 0) * 40ms);
   }
 
+  /* Smooth card hover lift — applied via card-call-hover */
+  .card-hover-lift {
+    transition: transform 200ms ease-in-out, box-shadow 200ms ease-in-out;
+  }
+  .card-hover-lift:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  }
+
+  /* Subtle fade-in for dynamic content */
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  .animate-fade-in {
+    animation: fade-in 200ms ease-out both;
+  }
+
+  /* Smooth page content transitions */
+  .page-enter {
+    animation: fade-in 150ms ease-out;
+  }
+
   /* Subtle amber glow for active sidebar nav items */
   .nav-active-glow {
     box-shadow:

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,12 +29,12 @@ import { SkeletonCard } from '@/components/ui/skeleton'
 
 // Recorder state config - keyed by string rec_state
 const RECORDER_STATES: Record<string, { label: string; badgeClass: string; cardClass: string; dotColor: string }> = {
-  available: { label: 'AVAILABLE', badgeClass: 'bg-indigo-800 text-indigo-300', cardClass: 'border-indigo-800/30 bg-indigo-950/20 card-recessed', dotColor: 'bg-indigo-500' },
-  recording: { label: 'RECORDING', badgeClass: 'bg-live text-white', cardClass: 'border-live/50 bg-red-950/40 card-recording-glow', dotColor: 'bg-live animate-pulse' },
-  idle: { label: 'IDLE', badgeClass: 'bg-amber-700 text-amber-200', cardClass: 'border-amber-700/40 bg-amber-950/20 card-recessed', dotColor: 'bg-amber-500' },
-  stopped: { label: 'STOPPED', badgeClass: 'bg-red-900 text-red-300', cardClass: 'border-red-900/40 bg-red-950/20 card-recessed', dotColor: 'bg-red-400' },
+  available: { label: 'AVAILABLE', badgeClass: 'bg-indigo-800 text-indigo-300', cardClass: 'border-indigo-800/30 bg-indigo-950/20 card-recessed card-hover-lift', dotColor: 'bg-indigo-500' },
+  recording: { label: 'RECORDING', badgeClass: 'bg-live text-white', cardClass: 'border-live/50 bg-red-950/40 card-recording-glow card-hover-lift', dotColor: 'bg-live animate-pulse' },
+  idle: { label: 'IDLE', badgeClass: 'bg-amber-700 text-amber-200', cardClass: 'border-amber-700/40 bg-amber-950/20 card-recessed card-hover-lift', dotColor: 'bg-amber-500' },
+  stopped: { label: 'STOPPED', badgeClass: 'bg-red-900 text-red-300', cardClass: 'border-red-900/40 bg-red-950/20 card-recessed card-hover-lift', dotColor: 'bg-red-400' },
 }
-const DEFAULT_STATE = { label: 'UNKNOWN', badgeClass: 'bg-zinc-700 text-zinc-400', cardClass: 'border-zinc-700/30 bg-zinc-900/20 card-recessed', dotColor: 'bg-zinc-500' }
+const DEFAULT_STATE = { label: 'UNKNOWN', badgeClass: 'bg-zinc-700 text-zinc-400', cardClass: 'border-zinc-700/30 bg-zinc-900/20 card-recessed card-hover-lift', dotColor: 'bg-zinc-500' }
 
 // Elapsed time display component
 function RecorderElapsed({ startTime }: { startTime: number }) {
@@ -258,9 +258,9 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 page-enter">
       {/* Compact stats bar */}
-      <div className="flex flex-wrap items-center gap-4 lg:gap-6 rounded-lg border stat-bar-glass px-4 py-3">
+      <div className="flex flex-wrap items-center gap-4 lg:gap-6 rounded-lg border stat-bar-glass card-glass px-4 py-3">
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">Recorders</span>
           <span className="text-xl font-bold tabular-nums">{recordingCount}</span>
@@ -468,7 +468,7 @@ export default function Dashboard() {
           {systemsArray.map((rate) => (
             <div
               key={rate.sys_name || rate.system_id}
-              className="flex items-center gap-3 rounded-lg border bg-card card-glass px-3 py-2"
+              className="flex items-center gap-3 rounded-lg border bg-card card-glass card-hover-lift px-3 py-2"
             >
               <div>
                 <div className="font-medium capitalize text-sm">


### PR DESCRIPTION
## Summary
- Added card-hover-lift class with smooth translateY/shadow transition to system status and recorder cards
- Added page-enter fade-in animation applied to main content area for smooth page transitions
- Added scrollbar-thin to main content scroll container
- Added card-glass class to stats bar for consistent glassmorphism across the dashboard
- Added animate-fade-in utility CSS class

Fixes #17