### PR TITLE
Make dashboard OpenAPI generation reproducible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ npm install           # Install dependencies
 npm run dev           # Start dev server on 0.0.0.0:5173
 npm run build         # Type-check (tsc -b) then build with Vite
 npm run lint          # Type-check only (tsc --noEmit)
-npm run api:generate  # Regenerate TypeScript types from OpenAPI spec
+npm run api:generate  # Regenerate TypeScript types from ../tr-engine/openapi.yaml
 ```
 
 There are no tests configured in this project. The `lint` command is the primary code quality check.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ npm run lint         # Type-check only
 npm run api:generate # Regenerate API types from OpenAPI spec
 ```
 
+`npm run api:generate` expects `tr-dashboard` and `tr-engine` to be checked out as sibling directories and reads the backend spec from `../tr-engine/openapi.yaml`.
+
 ## Write Access
 
 tr-dashboard supports inline editing of talkgroup metadata (name, group, tag, priority, description) and unit names directly from their detail pages.

--- a/docs/plans/2026-02-24-v073-migration-plan.md
+++ b/docs/plans/2026-02-24-v073-migration-plan.md
@@ -28,7 +28,7 @@ In `package.json`, change:
 ```
 To:
 ```json
-"api:generate": "openapi-typescript ./openapi.yaml -o src/api/generated.ts"
+"api:generate": "openapi-typescript ../tr-engine/openapi.yaml -o src/api/generated.ts"
 ```
 
 **Step 2: Run the generator**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tr-dashboard",
-  "version": "0.9.1",
+  "version": "1.0.0-pre10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tr-dashboard",
-      "version": "0.9.1",
+      "version": "1.0.0-pre10",
       "dependencies": {
         "@radix-ui/react-hover-card": "^1.1.15",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "tsc --noEmit",
-    "api:generate": "openapi-typescript ./openapi.yaml -o src/api/generated.ts"
+    "api:generate": "openapi-typescript ../tr-engine/openapi.yaml -o src/api/generated.ts"
   },
   "dependencies": {
     "@radix-ui/react-hover-card": "^1.1.15",

--- a/src/api/generated.ts
+++ b/src/api/generated.ts
@@ -32,14 +32,11 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Web auth bootstrap
-         * @description Returns the API auth token for web UI pages. No authentication required.
-         *     Used by `auth.js` to transparently authenticate browser-side API calls.
-         *     The URL has no file extension so CDNs (Cloudflare) skip caching it.
-         *
-         *     When a valid JWT is present in the request, the response includes a `user`
-         *     field with the authenticated user's info. The `user` field is absent (not null)
-         *     when no JWT session is present, preserving backward compatibility.
+         * Auth mode discovery
+         * @description Returns the engine's auth mode and any public read token.
+         *     Always available without authentication. Clients use this to
+         *     determine whether to prompt for a token, show a login form,
+         *     or skip auth entirely.
          */
         get: operations["getAuthInit"];
         put?: never;
@@ -1066,13 +1063,14 @@ export interface paths {
          *     trunk-recorder's upload plugin at `POST /api/v1/call-upload` and it
          *     works out of the box.
          *
-         *     **Authentication:** When `WRITE_TOKEN` is configured, this endpoint
-         *     requires the write token (uploads are write operations). Otherwise,
-         *     `AUTH_TOKEN` is accepted. In addition to the standard
-         *     `Authorization: Bearer` header and `?token=` query parameter, this
-         *     endpoint also accepts auth via the `key` (rdio-scanner) or `api_key`
-         *     (OpenMHz) multipart form fields. This allows trunk-recorder upload
-         *     plugins to authenticate without custom header configuration.
+         *     **Authentication:** Uploads are write operations. In full auth mode,
+         *     use an API key (`tre_...`) or an editor/admin JWT. In token mode,
+         *     use `AUTH_TOKEN`. The deprecated `WRITE_TOKEN` is still accepted for
+         *     legacy deployments. In addition to the standard `Authorization: Bearer`
+         *     header and `?token=` query parameter, this endpoint also accepts auth
+         *     via the `key` (rdio-scanner) or `api_key` (OpenMHz) multipart form
+         *     fields. This allows trunk-recorder upload plugins to authenticate
+         *     without custom header configuration.
          *
          *     **Format detection:** The endpoint inspects form field names to
          *     determine the upload format:
@@ -1773,6 +1771,104 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/maintenance/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update a retention setting
+         * @description Updates a single retention setting. The value is persisted to the
+         *     `config_overrides` table and applied immediately to the live pipeline.
+         *     Returns 409 if the key is locked by an environment variable.
+         *     Requires admin role.
+         */
+        put: operations["setMaintenanceConfig"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/maintenance/config/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Reset a retention setting to default
+         * @description Removes a DB-stored retention override and resets the setting to its
+         *     environment variable value (if set) or coded default. Returns 409 if
+         *     the key is locked by an environment variable.
+         *     Requires admin role.
+         */
+        delete: operations["deleteMaintenanceConfig"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/storage/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get database storage statistics
+         * @description Returns per-table row counts and sizes from `pg_stat_user_tables`,
+         *     plus partition breakdowns for large partitioned tables. Total
+         *     database size is included. If a per-table stat fails, the table is
+         *     omitted and an entry is added to `errors[]` — the rest of the
+         *     response still returns.
+         *     Requires admin role.
+         */
+        get: operations["getStorageStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/storage/purge/{table}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Manually purge old data from a table
+         * @description Triggers an immediate purge of rows (or partitions) older than the
+         *     specified duration. The `table` path parameter must be one of the
+         *     allowed purgeable tables. Purge runs with a 5-minute context
+         *     timeout — if it times out, `timed_out: true` is returned with
+         *     a partial count.
+         *
+         *     This action is irreversible.
+         *     Requires admin role.
+         */
+        post: operations["purgeTable"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1802,9 +1898,10 @@ export interface components {
          *     - **location**: unit location update
          *     - **ackresp**: acknowledge response
          *     - **signal**: in-band signaling decode (MDC1200, FleetSync, STAR)
+         *     - **call_alert**: directed unit-to-unit page (P25 TSBK 0x1F); `target_unit` and `target_unit_alpha_tag` present in SSE payload and `metadata_json`
          * @enum {string}
          */
-        EventType: "on" | "off" | "join" | "call" | "end" | "data" | "ans_req" | "location" | "ackresp" | "signal";
+        EventType: "on" | "off" | "join" | "call" | "end" | "data" | "ans_req" | "location" | "ackresp" | "signal" | "call_alert";
         /**
          * @description Call recording state (mapped from trunk-recorder integer values):
          *     - **monitoring**: control channel activity seen, no audio capture yet
@@ -2407,6 +2504,18 @@ export interface components {
              * @example normal
              */
             signal_type?: string;
+            /**
+             * @description Unit ID of the radio being paged (P25 Call Alert, TSBK 0x1F).
+             *     Only present in SSE payloads for `unit_event:call_alert` events.
+             * @example 4811289
+             */
+            target_unit?: number;
+            /**
+             * @description Alpha tag for the paged unit, if known.
+             *     Only present in SSE payloads for `unit_event:call_alert` events.
+             * @example OFFICER JONES
+             */
+            target_unit_alpha_tag?: string;
         };
         /**
          * @description A frequency segment from trunk-recorder's freqList. Each entry
@@ -3604,7 +3713,7 @@ export interface components {
             /** @description Results of the last maintenance run. Null if no run has completed since startup. */
             last_run?: components["schemas"]["MaintenanceRun"] | null;
         };
-        /** @description Active retention settings for automatic maintenance. */
+        /** @description Active retention settings for automatic maintenance. Each setting includes a `_source` ("env", "db", or "default") and a `_locked` flag (true when set by environment variable and immutable through the API). */
         MaintenanceConfig: {
             /**
              * @description Raw MQTT message retention (Go duration, e.g. 168h = 7 days)
@@ -3612,25 +3721,76 @@ export interface components {
              */
             retention_raw_messages?: string;
             /**
+             * @description Where this value originates
+             * @example env
+             * @enum {string}
+             */
+            retention_raw_messages_source?: "env" | "db" | "default";
+            /**
+             * @description True when set by environment variable (immutable through API)
+             * @example true
+             */
+            retention_raw_messages_locked?: boolean;
+            /**
              * @description Console log retention (Go duration, e.g. 720h = 30 days)
              * @example 720h0m0s
              */
             retention_console_logs?: string;
+            /**
+             * @example db
+             * @enum {string}
+             */
+            retention_console_logs_source?: "env" | "db" | "default";
+            /** @example false */
+            retention_console_logs_locked?: boolean;
             /**
              * @description Plugin status retention (Go duration)
              * @example 720h0m0s
              */
             retention_plugin_status?: string;
             /**
+             * @example default
+             * @enum {string}
+             */
+            retention_plugin_status_source?: "env" | "db" | "default";
+            /** @example false */
+            retention_plugin_status_locked?: boolean;
+            /**
+             * @description Trunking message retention (Go duration, default 720h = 30 days)
+             * @example 720h0m0s
+             */
+            retention_trunking_messages?: string;
+            /**
+             * @example default
+             * @enum {string}
+             */
+            retention_trunking_messages_source?: "env" | "db" | "default";
+            /** @example false */
+            retention_trunking_messages_locked?: boolean;
+            /**
              * @description Active call checkpoint retention (Go duration)
              * @example 168h0m0s
              */
             retention_checkpoints?: string;
             /**
+             * @example env
+             * @enum {string}
+             */
+            retention_checkpoints_source?: "env" | "db" | "default";
+            /** @example true */
+            retention_checkpoints_locked?: boolean;
+            /**
              * @description Stale incomplete call retention (Go duration)
              * @example 1h0m0s
              */
             retention_stale_calls?: string;
+            /**
+             * @example default
+             * @enum {string}
+             */
+            retention_stale_calls_source?: "env" | "db" | "default";
+            /** @example false */
+            retention_stale_calls_locked?: boolean;
             /**
              * @description Maintenance run schedule
              * @example every 24h
@@ -3808,6 +3968,140 @@ export interface components {
              */
             started_at?: string;
         };
+        /** @description Request body for updating a retention setting. */
+        RetentionConfigUpdate: {
+            /**
+             * @description Retention config key
+             * @example retention_console_logs
+             * @enum {string}
+             */
+            key: "retention_raw_messages" | "retention_console_logs" | "retention_plugin_status" | "retention_trunking_messages" | "retention_checkpoints" | "retention_stale_calls";
+            /**
+             * @description Go duration string (e.g. 48h, 720h, 7d)
+             * @example 48h
+             */
+            value: string;
+        };
+        /** @description Database storage statistics including per-table sizes and partition breakdowns. */
+        StorageStats: {
+            /**
+             * Format: int64
+             * @description Total database size in bytes
+             * @example 8589934592
+             */
+            total_db_bytes?: number;
+            /** @description Per-table size information, sorted by total_bytes descending */
+            tables?: components["schemas"]["TableSizeInfo"][];
+            /**
+             * @description Per-table errors that occurred during stat collection. Affected tables are omitted from `tables`.
+             * @example [
+             *       "failed to get partitions for some_table: connection timeout"
+             *     ]
+             */
+            errors?: string[];
+        };
+        /** @description Size information for a single database table. */
+        TableSizeInfo: {
+            /**
+             * @description Table name
+             * @example mqtt_raw_messages
+             */
+            name?: string;
+            /**
+             * Format: int64
+             * @description Estimated live row count (from pg_stat_user_tables)
+             * @example 4200000
+             */
+            row_count?: number;
+            /**
+             * Format: int64
+             * @description Table data size in bytes (pg_table_size)
+             * @example 5368709120
+             */
+            table_bytes?: number;
+            /**
+             * Format: int64
+             * @description Index size in bytes (pg_indexes_size)
+             * @example 536870912
+             */
+            index_bytes?: number;
+            /**
+             * Format: int64
+             * @description Total relation size in bytes (pg_total_relation_size)
+             * @example 5905580032
+             */
+            total_bytes?: number;
+            /** @description Per-partition breakdown. Only present for partitioned tables. */
+            partitions?: components["schemas"]["PartitionInfo"][];
+        };
+        /** @description Size information for a single table partition. */
+        PartitionInfo: {
+            /**
+             * @description Partition name
+             * @example mqtt_raw_messages_2026_w14
+             */
+            name?: string;
+            /**
+             * Format: int64
+             * @description Total relation size in bytes
+             * @example 2684354560
+             */
+            total_bytes?: number;
+        };
+        /** @description Request body for manual table purge. */
+        PurgeRequest: {
+            /**
+             * @description Rows/partitions older than this duration will be deleted (Go duration, e.g. 48h, 7d)
+             * @example 48h
+             */
+            older_than: string;
+        };
+        /** @description Response from a manual table purge operation. */
+        PurgeResponse: {
+            /**
+             * @description Table that was purged
+             * @example mqtt_raw_messages
+             */
+            table?: string;
+            /**
+             * @description The duration threshold that was used
+             * @example 48h
+             */
+            older_than?: string;
+            /**
+             * Format: int64
+             * @description Number of rows deleted (null for partition-drop purges)
+             * @example null
+             */
+            rows_deleted?: number | null;
+            /**
+             * @description Number of partitions dropped (null for row-delete purges)
+             * @example 2
+             */
+            partitions_dropped?: number | null;
+            /**
+             * @description Names of dropped partitions (only when partitions were dropped)
+             * @example [
+             *       "mqtt_raw_messages_2025_w48"
+             *     ]
+             */
+            partitions_dropped_names?: string[];
+            /**
+             * @description True if the 5-minute context deadline expired before completion
+             * @example false
+             */
+            timed_out?: boolean;
+            /**
+             * @description Wall-clock duration of the purge operation in milliseconds
+             * @example 4823
+             */
+            duration_ms?: number;
+            /**
+             * @description Always present, reminding that this action is irreversible
+             * @example This action is irreversible.
+             */
+            warning?: string;
+        };
     };
     responses: {
         /** @description Bad Request */
@@ -3943,30 +4237,26 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Token payload */
+            /** @description Auth mode info */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
-                        /** @description Bearer token for API authentication */
-                        token: string;
-                        /** @description Present only when a valid JWT session exists */
-                        user?: {
-                            username?: string;
-                            /** @enum {string} */
-                            role?: "viewer" | "editor" | "admin";
-                        };
+                        /**
+                         * @description - open: no auth required
+                         *     - token: shared API token required (not returned here)
+                         *     - full: JWT login available, optional public read token
+                         * @enum {string}
+                         */
+                        mode: "open" | "token" | "full";
+                        /** @description Public read token (only in full mode with AUTH_TOKEN set) */
+                        read_token?: string | null;
+                        /** @description Whether JWT login endpoints are available */
+                        jwt_enabled: boolean;
                     };
                 };
-            };
-            /** @description Auth not configured (AUTH_TOKEN not set and auto-generation failed) */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };
@@ -6912,6 +7202,168 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setMaintenanceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RetentionConfigUpdate"];
+            };
+        };
+        responses: {
+            /** @description Retention setting updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example retention_console_logs */
+                        key?: string;
+                        /** @example 48h0m0s */
+                        value?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description Key is locked by environment variable */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Pipeline not running */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteMaintenanceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Retention config key (e.g. retention_console_logs) */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Retention override removed, reset to default */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example retention_console_logs */
+                        key?: string;
+                        /** @example reset to default */
+                        status?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description Key is locked by environment variable */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Pipeline not running */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getStorageStats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Storage stats */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StorageStats"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            500: components["responses"]["InternalError"];
+        };
+    };
+    purgeTable: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Purgeable table key (see allowlist) */
+                table: "mqtt_raw_messages" | "console_messages" | "trunking_messages" | "plugin_statuses" | "call_active_checkpoints";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PurgeRequest"];
+            };
+        };
+        responses: {
+            /** @description Purge completed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PurgeResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            500: components["responses"]["InternalError"];
+            /** @description Purge timed out (partial results included) */
+            504: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PurgeResponse"];
                 };
             };
         };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,563 +1,159 @@
 /**
- * API Types for tr-engine v0.7.3
+ * API Types for tr-engine.
  *
- * Hand-written types matching the OpenAPI spec. Reference: /openapi.yaml
- * Auto-generated types: npm run api:generate → src/api/generated.ts
+ * Most exported types are aliases to the generated OpenAPI schemas.
+ * Regenerate with: npm run api:generate
  */
+
+import type { components } from './generated'
+
+type Schema = components['schemas']
 
 // =============================================================================
 // Enums
 // =============================================================================
 
-export type SystemType = string
-
-export type TalkgroupMode = 'D' | 'A' | 'E' | 'M' | 'T'
-
-export type EventType = 'on' | 'off' | 'join' | 'call' | 'end' | 'data' | 'ans_req' | 'location' | 'ackresp' | 'signal'
-
-export type CallState = 'monitoring' | 'recording' | 'stopped' | 'completed'
-
-export type MonState = 'unspecified' | 'active' | 'duplicate'
-
-export type RecState = 'available' | 'recording' | 'idle' | 'stopped'
-
-export type TranscriptionStatus = 'none' | 'auto' | 'reviewed' | 'verified' | 'excluded'
-
-export type TranscriptionSource = 'auto' | 'human' | 'llm'
-
-export type SSEEventType =
-  | 'call_start'
-  | 'call_update'
-  | 'call_end'
-  | 'unit_event'
-  | 'recorder_update'
-  | 'rate_update'
-  | 'trunking_message'
-  | 'console'
+export type SystemType = Schema['SystemType']
+export type TalkgroupMode = Schema['TalkgroupMode']
+export type EventType = Schema['EventType']
+export type CallState = Schema['CallState']
+export type MonState = Schema['MonState']
+export type RecState = Schema['RecState']
+export type TranscriptionStatus = Schema['TranscriptionStatus']
+export type TranscriptionSource = Schema['TranscriptionSource']
+export type SSEEventType = Schema['SSEEventType']
 
 // =============================================================================
 // Core Models
 // =============================================================================
 
-/** Logical radio network (P25 WACN-level or conventional system) */
-export interface System {
-  system_id: number
-  system_type: SystemType
-  name?: string
-  sysid?: string
-  wacn?: string
+export type System = Omit<Schema['System'], 'sites'> & {
   sites?: Site[]
 }
-
-/** Recording site — one trunk-recorder sys_name monitoring a system */
-export interface Site {
-  site_id: number
+export type Site = Schema['Site'] & {
   system_id: number
-  short_name: string
-  instance_id?: string
-  nac?: string
-  rfss?: number
-  p25_site_id?: number
-  sys_num?: number
 }
-
-/** P25 system grouped by network with sites */
-export interface P25System {
-  system_id: number
-  name?: string
-  sysid?: string
-  wacn?: string
-  sites?: Site[]
-  talkgroup_count?: number
-  unit_count?: number
-  calls_24h?: number
-}
-
-/** A talkgroup on a radio system */
-export interface Talkgroup {
-  system_id: number
-  system_name?: string
-  sysid?: string
-  tgid: number
-  alpha_tag?: string
-  tag?: string
-  group?: string
-  description?: string
-  mode?: TalkgroupMode
-  priority?: number
-  first_seen?: string
-  last_seen?: string
-  call_count?: number
-  calls_1h?: number
-  calls_24h?: number
-  unit_count?: number
-  relevance_score?: number
-}
-
-/** A radio unit (mobile or portable radio) */
-export interface Unit {
-  system_id: number
-  system_name?: string
-  sysid?: string
-  unit_id: number
-  alpha_tag?: string
-  alpha_tag_source?: string
-  first_seen?: string
-  last_seen?: string
-  last_event_type?: EventType
-  last_event_time?: string
-  last_event_tgid?: number
-  last_event_tg_tag?: string
-  relevance_score?: number
-}
-
-/** A unit event (registration, affiliation, call activity, signal decode) */
-export interface UnitEvent {
-  id: number
-  event_type: EventType
-  time: string
-  system_id?: number
-  system_name?: string
-  unit_rid: number
-  unit_alpha_tag?: string
-  tgid?: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  instance_id?: string
-  metadata_json?: Record<string, unknown>
-  // Signal event fields (SSE sends these top-level, REST puts them in metadata_json)
-  signaling_type?: string   // MDC1200, FLEETSYNC, STAR, unknown
-  signal_type?: string      // normal, emergency, radio_check, etc.
-}
-
-/** A recorded radio call */
-export interface Call {
-  // Identifiers
-  call_id: number
-  call_group_id?: number
-
-  // System context
-  system_id: number
-  system_name?: string
-  sysid?: string
-
-  // Site context
-  site_id?: number
-  site_short_name?: string
-
-  // Talkgroup context
-  tgid: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  tg_tag?: string
-  tg_group?: string
-
-  // Timing
-  start_time: string
-  stop_time?: string | null
-  duration?: number
-
-  // Audio
-  audio_url?: string | null
-  audio_type?: string
-  audio_size?: number
-
-  // Signal quality
-  freq?: number
-  freq_error?: number
-  signal_db?: number | null
-  noise_db?: number | null
-  error_count?: number
-  spike_count?: number
-
-  // Status
-  call_state?: CallState
-  mon_state?: MonState
-  emergency?: boolean
-  encrypted?: boolean
-  analog?: boolean
-  conventional?: boolean
-  phase2_tdma?: boolean
-  tdma_slot?: number
-
-  // Patches
-  patched_tgids?: number[]
-
-  // Inline transmission/frequency data (JSONB)
+export type P25System = Schema['P25System']
+export type Talkgroup = Schema['Talkgroup']
+export type Unit = Schema['Unit']
+export type UnitEvent = Schema['UnitEvent']
+export type Call = Omit<Schema['Call'], 'src_list' | 'freq_list'> & {
   src_list?: CallTransmission[]
   freq_list?: CallFrequency[]
-  unit_ids?: number[]
-
-  // Units on this call
-  units?: CallUnit[]
-
-  // Transcription (denormalized)
-  has_transcription?: boolean
-  transcription_status?: TranscriptionStatus
-  transcription_text?: string | null
-  transcription_word_count?: number | null
-
-  // Extensible metadata
-  metadata_json?: Record<string, unknown>
 }
-
-/** A unit that transmitted during a call */
-export interface CallUnit {
-  system_id: number
-  unit_id: number
-  alpha_tag?: string
-}
-
-/** A unit key-up from trunk-recorder's srcList */
-export interface CallTransmission {
+export type CallUnit = Schema['CallUnit']
+export type CallTransmission = Schema['CallTransmission'] & {
   src: number
-  tag?: string
   time: number
   pos: number
   duration: number
   emergency: number
-  signal_system?: string
 }
-
-/** A frequency segment from trunk-recorder's freqList */
-export interface CallFrequency {
+export type CallFrequency = Schema['CallFrequency'] & {
   freq: number
   time: number
   pos: number
   len: number
-  error_count?: number
-  spike_count?: number
 }
-
-/** A group of duplicate call recordings from multiple recorders */
-export interface CallGroup {
-  id: number
-  system_id?: number
-  system_name?: string
-  sysid?: string
-  site_id?: number
-  site_short_name?: string
-  tgid?: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  tg_tag?: string
-  tg_group?: string
-  start_time?: string
-  stop_time?: string
-  duration?: number
-  call_count?: number
-  primary_call_id?: number
-  has_transcription?: boolean
-  transcription_status?: TranscriptionStatus
-  transcription_text?: string | null
-}
-
-/** A transcription of a call's audio content */
-export interface Transcription {
-  id: number
-  call_id: number
-  text: string
-  source: TranscriptionSource
-  is_primary?: boolean
-  confidence?: number | null
-  language?: string
-  model?: string
-  provider?: string
-  word_count?: number
-  duration_ms?: number
-  created_at?: string
-  words?: {
-    words?: AttributedWord[]
-    segments?: TranscriptionSegment[]
-  }
-}
-
-/** A word with timing and unit attribution */
-export interface AttributedWord {
-  word: string
-  start: number
-  end: number
-  src: number
-  src_tag?: string
-}
-
-/** Consecutive words from the same radio unit */
-export interface TranscriptionSegment {
-  src: number
-  src_tag?: string
-  start: number
-  end: number
-  text: string
-}
-
-/** Trunk-recorder recorder (SDR channel) */
-export interface Recorder {
+export type CallGroup = Schema['CallGroup']
+export type Transcription = Schema['Transcription']
+export type AttributedWord = Schema['AttributedWord']
+export type TranscriptionSegment = Schema['TranscriptionSegment']
+export type Recorder = Schema['Recorder'] & {
   id: string
+  src_num: number
+  rec_num: number
+  freq: number
+  duration: number
+  count: number
   instance_id?: string
   system_id?: number | null
-  src_num?: number
-  rec_num?: number
-  type?: string
-  rec_state?: RecState
-  freq?: number
-  duration?: number
-  count?: number
-  squelched?: boolean
-  tgid?: number | null
-  tg_alpha_tag?: string | null
-  unit_id?: number | null
-  unit_alpha_tag?: string | null
 }
-
-/** Live talkgroup affiliation entry */
-export interface Affiliation {
-  system_id: number
-  system_name?: string
-  sysid?: string
-  unit_id: number
-  unit_alpha_tag?: string
-  tgid: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  tg_tag?: string
-  tg_group?: string
-  previous_tgid?: number | null
-  affiliated_since: string
-  last_event_time: string
-  status: 'affiliated' | 'off'
-}
-
-/** Talkgroup directory entry (from CSV import) */
-export interface TalkgroupDirectoryEntry {
-  system_id?: number
-  system_name?: string
-  tgid?: number
-  alpha_tag?: string
-  mode?: string
-  description?: string
-  tag?: string
-  category?: string
-  priority?: number | null
-}
+export type Affiliation = Schema['Affiliation']
+export type TalkgroupDirectoryEntry = Schema['TalkgroupDirectoryEntry']
 
 // =============================================================================
 // Response Wrappers
 // =============================================================================
 
-export interface SystemListResponse {
+export interface SystemListResponse extends Omit<Schema['SystemListResponse'], 'systems'> {
   systems: System[]
-  total: number
 }
-
-export interface P25SystemListResponse {
-  systems: P25System[]
-  total: number
-}
-
-export interface TalkgroupListResponse {
-  talkgroups: Talkgroup[]
-  total: number
-  limit: number
-  offset: number
-}
-
-export interface UnitListResponse {
-  units: Unit[]
-  total: number
-  limit: number
-  offset: number
-}
-
-export interface UnitEventListResponse {
-  events: UnitEvent[]
-  total: number
-  limit: number
-  offset: number
-}
-
-export interface CallListResponse {
+export type P25SystemListResponse = Schema['P25SystemListResponse']
+export type TalkgroupListResponse = Schema['TalkgroupListResponse']
+export type UnitListResponse = Schema['UnitListResponse']
+export type UnitEventListResponse = Schema['UnitEventListResponse']
+export interface CallListResponse extends Omit<Schema['CallListResponse'], 'calls'> {
   calls: Call[]
-  total: number
-  limit: number
-  offset: number
 }
-
-export interface ActiveCallListResponse {
+export interface ActiveCallListResponse extends Omit<Schema['ActiveCallListResponse'], 'calls'> {
   calls: Call[]
-  total: number
 }
-
-export interface CallGroupListResponse {
+export interface CallGroupListResponse extends Omit<Schema['CallGroupListResponse'], 'call_groups'> {
   call_groups: CallGroup[]
-  total: number
-  limit: number
-  offset: number
 }
-
-export interface CallGroupDetailResponse {
+export interface CallGroupDetailResponse extends Omit<Schema['CallGroupDetailResponse'], 'call_group' | 'calls'> {
   call_group: CallGroup
   calls: Call[]
 }
-
-export interface CallFrequencyListResponse {
+export interface CallFrequencyListResponse extends Omit<Schema['CallFrequencyListResponse'], 'frequencies'> {
   frequencies: CallFrequency[]
-  total: number
 }
-
-export interface CallTransmissionListResponse {
+export interface CallTransmissionListResponse extends Omit<Schema['CallTransmissionListResponse'], 'transmissions'> {
   transmissions: CallTransmission[]
-  total: number
 }
-
-export interface AffiliationListResponse {
-  affiliations: Affiliation[]
-  total: number
-  limit: number
-  offset: number
-  summary: {
-    talkgroup_counts: Record<string, number>
-  }
-}
-
+export type AffiliationListResponse = Schema['AffiliationListResponse']
 export interface TalkgroupDirectoryListResponse {
   talkgroups: TalkgroupDirectoryEntry[]
   total: number
   limit: number
   offset: number
 }
-
-export interface TranscriptionSearchHit {
+export type TranscriptionSearchHit = Schema['TranscriptionSearchHit'] & {
   id: number
   call_id: number
   text: string
-  source?: string
-  is_primary?: boolean
-  word_count?: number
-  duration_ms?: number
-  created_at?: string
-  rank?: number
-  system_id?: number
-  system_name?: string
-  tgid?: number
-  tg_alpha_tag?: string
-  call_start_time?: string
-  call_duration?: number | null
 }
-
-export interface TranscriptionSearchResponse {
+export interface TranscriptionSearchResponse extends Omit<Schema['TranscriptionSearchResponse'], 'results'> {
   results: TranscriptionSearchHit[]
-  total: number
-  limit: number
-  offset: number
 }
-
-export interface TranscriptionQueueStats {
-  status: string
-  pending?: number
-  completed?: number
-  failed?: number
-}
-
-export interface RecorderListResponse {
+export type TranscriptionQueueStats = Schema['TranscriptionQueueStats']
+export interface RecorderListResponse extends Omit<Schema['RecorderListResponse'], 'recorders'> {
   recorders: Recorder[]
-  total: number
 }
 
 // =============================================================================
 // Stats Types
 // =============================================================================
 
-export interface StatsResponse {
-  systems?: number
-  talkgroups?: number
-  units?: number
-  total_calls?: number
-  calls_24h?: number
-  calls_1h?: number
-  total_duration_hours?: number
+export type SystemActivity = Schema['SystemActivity'] & {
+  system_id: number
+}
+export interface StatsResponse extends Omit<Schema['StatsResponse'], 'system_activity'> {
   system_activity?: SystemActivity[]
 }
-
-export interface SystemActivity {
+export type DecodeRate = Schema['DecodeRate'] & {
   system_id: number
-  system_name?: string
-  sysid?: string
-  calls_1h?: number
-  calls_24h?: number
-  active_talkgroups?: number
-  active_units?: number
-}
-
-export interface DecodeRate {
-  time?: string
-  system_id: number
-  system_name?: string
   sys_name?: string
-  sysid?: string
   decode_rate: number
   total_messages?: number
-  control_channel?: number
 }
-
-export interface DecodeRatesResponse {
+export interface DecodeRatesResponse extends Omit<Schema['DecodeRatesResponse'], 'rates'> {
   rates: DecodeRate[]
-  total: number
 }
-
-export interface TalkgroupActivity {
-  system_id?: number
-  system_name?: string
-  tgid?: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  tg_tag?: string
-  tg_group?: string
-  call_count?: number
-  total_duration?: number
-  emergency_count?: number
-  first_call?: string
-  last_call?: string
-}
-
+export type TalkgroupActivity = Schema['TalkgroupActivity']
 export interface TalkgroupActivityResponse {
   activity: TalkgroupActivity[]
   total: number
 }
-
-export interface TalkgroupEncryptionStat {
-  system_id?: number
-  system_name?: string
-  sysid?: string
-  tgid?: number
-  tg_alpha_tag?: string
-  tg_description?: string
-  tg_tag?: string
-  tg_group?: string
-  encrypted_count?: number
-  clear_count?: number
-  total_count?: number
-  encrypted_pct?: number
-}
-
-export interface EncryptionStatsResponse {
-  stats: TalkgroupEncryptionStat[]
-  total: number
-  hours?: number
-}
+export type TalkgroupEncryptionStat = Schema['TalkgroupEncryptionStat']
+export type EncryptionStatsResponse = Schema['EncryptionStatsResponse']
 
 // =============================================================================
 // Health
 // =============================================================================
 
-export interface HealthResponse {
-  status: string
-  version?: string
-  uptime_seconds?: number
-  checks?: {
-    database?: string
-    mqtt?: string
-    transcription?: string
-  }
+export interface HealthResponse extends Omit<Schema['HealthResponse'], 'trunk_recorders'> {
   trunk_recorders?: Array<{
     instance_id: string
     status: string
@@ -569,106 +165,40 @@ export interface HealthResponse {
 // Admin
 // =============================================================================
 
-export interface SystemMergeRequest {
-  source_id: number
-  target_id: number
+export interface SystemMergeRequest extends Omit<Schema['SystemMergeRequest'], 'update_target_metadata'> {
   update_target_metadata?: boolean
 }
-
-export interface SystemMergeResponse {
-  target_id: number
-  source_id: number
-  calls_moved: number
-  talkgroups_moved: number
-  talkgroups_merged: number
-  units_moved: number
-  units_merged: number
-  events_moved: number
-}
-
-
-export interface MaintenanceConfig {
+export type SystemMergeResponse = Schema['SystemMergeResponse']
+export type MaintenanceConfig = Schema['MaintenanceConfig'] & {
   retention_calls?: string
-  retention_raw_messages?: string
-  retention_console_logs?: string
-  retention_plugin_status?: string
-  retention_checkpoints?: string
-  retention_stale_calls?: string
-  schedule?: string
 }
-
-export interface MaintenanceRun {
+export type MaintenanceRun = Schema['MaintenanceRun'] & {
   started_at: string
   completed_at?: string
-  partitions_created?: number
   calls_deleted?: number
   raw_messages_deleted?: number
   console_logs_deleted?: number
   errors?: string[]
 }
-
-export interface MaintenanceStatusResponse {
+export interface MaintenanceStatusResponse extends Omit<Schema['MaintenanceStatus'], 'config' | 'last_run'> {
   config?: MaintenanceConfig
   last_run?: MaintenanceRun | null
   running?: boolean
 }
-
-export interface MaintenanceRunResponse {
-  started_at: string
-  completed_at?: string
-  partitions_created?: number
-  calls_deleted?: number
-  raw_messages_deleted?: number
-  console_logs_deleted?: number
-  errors?: string[]
-}
+export type MaintenanceRunResponse = MaintenanceRun
 
 // =============================================================================
 // Error Types
 // =============================================================================
 
-export interface ErrorResponse {
-  error: string
-  detail?: string
-}
-
-export interface AmbiguousError {
-  error: string
-  matches: Array<{
-    system_id: number
-    system_name?: string
-    sysid?: string
-  }>
-}
+export type ErrorResponse = Schema['Error']
+export type AmbiguousError = Schema['AmbiguousError']
 
 // =============================================================================
 // Patch Types (for PATCH requests)
 // =============================================================================
 
-export interface SystemPatch {
-  sysid?: string
-  wacn?: string
-  name?: string
-}
-
-export interface SitePatch {
-  short_name?: string
-  instance_id?: string
-  nac?: string
-  rfss?: number
-  p25_site_id?: number
-}
-
-export interface TalkgroupPatch {
-  alpha_tag?: string
-  alpha_tag_source?: string
-  description?: string
-  group?: string
-  tag?: string
-  priority?: number
-}
-
-export interface UnitPatch {
-  alpha_tag?: string
-  alpha_tag_source?: string
-}
+export type SystemPatch = Schema['SystemPatch']
+export type SitePatch = Schema['SitePatch']
+export type TalkgroupPatch = Schema['TalkgroupPatch']
+export type UnitPatch = Schema['UnitPatch']


### PR DESCRIPTION
## Summary
- generate dashboard API types from sibling tr-engine openapi.yaml
- document the paired-checkout requirement
- move dashboard API exports toward generated schema aliases with compatibility wrappers for current UI assumptions

## Verification
- npm run api:generate
- npm run lint
- npm run build