### PR TITLE
Standardize dashboard query layer

### DIFF
--- a/docs/data-query-layer.md
+++ b/docs/data-query-layer.md
@@ -1,0 +1,70 @@
+# Dashboard Data Query Layer
+
+Server data flows through three layers:
+
+1. `src/api/client.ts` owns HTTP transport, auth headers, refresh handling, and typed endpoint functions.
+2. `src/api/services.ts` defines domain services and stable `queryKeys` for pages and components.
+3. `src/api/query.ts` provides `QueryProvider`, `useApiQuery`, `useApiMutation`, cache invalidation, request de-duplication, stale-time handling, and normalized loading/error flags.
+
+Pages should call domain services through `useApiQuery` instead of keeping their own fetch/cache effects. Use page state, URL params, and Zustand only for client state.
+
+## Reads
+
+Use a domain query key plus a service function:
+
+```tsx
+const callsQuery = useApiQuery(
+  queryKeys.calls.list(params),
+  () => callService.list(params),
+  { staleTime: 10_000 }
+)
+```
+
+The returned state is the standard shape for server reads:
+
+- `data`: last successful response, if any
+- `isLoading`: first load with no cached data
+- `isFetching`: any in-flight request, including refreshes
+- `error` / `isError`: displayable error state
+- `refetch`: forced refresh for manual reload actions
+
+Use explicit empty states when `!isLoading && data` exists but the collection is empty. Keep loading skeletons for `isLoading`, and preserve old `data` during background refreshes.
+
+## Pagination
+
+Paginated params belong in the query key:
+
+```tsx
+const params = { limit: pageSize, offset, sort: '-start_time' }
+useApiQuery(queryKeys.calls.list(params), () => callService.list(params))
+```
+
+List responses should use the backend `total` with the local `limit` and `offset`. Do not concatenate pages into a Zustand store unless the UX deliberately needs an infinite list cache; document that exception next to the store.
+
+## Writes
+
+Use `useApiMutation` for server writes and invalidate the affected domain keys:
+
+```tsx
+const updateTalkgroup = useApiMutation(
+  ({ id, patch }) => talkgroupService.update(id, patch),
+  { invalidate: [queryKeys.talkgroups.all] }
+)
+```
+
+Mutation handlers should keep optimistic UI local and short-lived. After success, invalidation makes the server cache authoritative again.
+
+## Refresh And Realtime
+
+Use `refetch()` for explicit user refresh actions. Realtime stores may overlay live data on top of query results, as `Calls` does for active calls, but the REST query remains the source of truth for historical data and pagination totals.
+
+## Zustand Boundary
+
+Zustand is for UI/client state: auth/session tokens, audio playback, filters, theme, thresholds, PWA update flags, alert settings, and realtime overlays. It should not be the default cache for REST responses.
+
+Existing exceptions:
+
+- `useTranscriptionCache` caches per-call transcription previews for call cards while list pages migrate to the shared query layer.
+- `useRealtimeStore` stores SSE state because it is event-stream state, not a REST snapshot.
+
+New REST-backed stores should not be added without documenting why `useApiQuery` is insufficient.

--- a/src/api/query.tsx
+++ b/src/api/query.tsx
@@ -1,0 +1,187 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+
+export type QueryKey = readonly unknown[]
+
+export interface QueryState<T> {
+  data: T | undefined
+  error: Error | null
+  isLoading: boolean
+  isFetching: boolean
+  isError: boolean
+  isSuccess: boolean
+  refetch: () => Promise<T>
+}
+
+export interface MutationState<TData, TVariables> {
+  data: TData | undefined
+  error: Error | null
+  isPending: boolean
+  mutate: (variables: TVariables) => Promise<TData>
+}
+
+interface CacheEntry<T> {
+  data?: T
+  error?: Error
+  updatedAt: number
+  promise?: Promise<T>
+}
+
+interface QueryClientValue {
+  getEntry: <T>(key: QueryKey) => CacheEntry<T> | undefined
+  fetchQuery: <T>(key: QueryKey, queryFn: () => Promise<T>, staleTime?: number, force?: boolean) => Promise<T>
+  invalidateQueries: (prefix?: QueryKey) => void
+}
+
+const QueryClientContext = createContext<QueryClientValue | null>(null)
+const DEFAULT_STALE_TIME_MS = 30_000
+
+function serializeKey(key: QueryKey): string {
+  return JSON.stringify(key)
+}
+
+function keyMatchesPrefix(key: QueryKey, prefix: QueryKey): boolean {
+  if (prefix.length > key.length) return false
+  return prefix.every((part, index) => serializeKey([part]) === serializeKey([key[index]]))
+}
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const cacheRef = useRef(new Map<string, CacheEntry<unknown>>())
+
+  const value = useMemo<QueryClientValue>(() => ({
+    getEntry: <T,>(key: QueryKey) => cacheRef.current.get(serializeKey(key)) as CacheEntry<T> | undefined,
+    fetchQuery: async <T,>(key: QueryKey, queryFn: () => Promise<T>, staleTime = DEFAULT_STALE_TIME_MS, force = false) => {
+      const cacheKey = serializeKey(key)
+      const existing = cacheRef.current.get(cacheKey) as CacheEntry<T> | undefined
+      const isFresh = existing?.data !== undefined && Date.now() - existing.updatedAt < staleTime
+      if (!force && isFresh) return existing.data as T
+      if (!force && existing?.promise) return existing.promise
+
+      const promise = queryFn()
+        .then((data) => {
+          cacheRef.current.set(cacheKey, { data, updatedAt: Date.now() })
+          return data
+        })
+        .catch((err: unknown) => {
+          const error = err instanceof Error ? err : new Error(String(err))
+          cacheRef.current.set(cacheKey, { error, updatedAt: Date.now() })
+          throw error
+        })
+
+      cacheRef.current.set(cacheKey, { data: existing?.data, error: existing?.error, updatedAt: existing?.updatedAt ?? 0, promise })
+      return promise
+    },
+    invalidateQueries: (prefix?: QueryKey) => {
+      if (!prefix) {
+        cacheRef.current.clear()
+        return
+      }
+      for (const key of cacheRef.current.keys()) {
+        const parsed = JSON.parse(key) as QueryKey
+        if (keyMatchesPrefix(parsed, prefix)) cacheRef.current.delete(key)
+      }
+    },
+  }), [])
+
+  return <QueryClientContext.Provider value={value}>{children}</QueryClientContext.Provider>
+}
+
+export function useQueryClient(): QueryClientValue {
+  const client = useContext(QueryClientContext)
+  if (!client) throw new Error('useQueryClient must be used inside QueryProvider')
+  return client
+}
+
+export function useApiQuery<T>(
+  key: QueryKey,
+  queryFn: () => Promise<T>,
+  options?: { enabled?: boolean; staleTime?: number }
+): QueryState<T> {
+  const client = useQueryClient()
+  const keyString = useMemo(() => serializeKey(key), [key])
+  const stableKey = useMemo(() => key, [keyString])
+  const queryFnRef = useRef(queryFn)
+  const initialEntry = client.getEntry<T>(stableKey)
+  const [data, setData] = useState<T | undefined>(initialEntry?.data)
+  const [error, setError] = useState<Error | null>(initialEntry?.error ?? null)
+  const [isFetching, setIsFetching] = useState(false)
+  const enabled = options?.enabled ?? true
+  const staleTime = options?.staleTime ?? DEFAULT_STALE_TIME_MS
+
+  useEffect(() => {
+    queryFnRef.current = queryFn
+  }, [queryFn])
+
+  const execute = useCallback(async (force = false) => {
+    setIsFetching(true)
+    setError(null)
+    try {
+      const result = await client.fetchQuery(stableKey, queryFnRef.current, staleTime, force)
+      setData(result)
+      return result
+    } catch (err) {
+      const nextError = err instanceof Error ? err : new Error(String(err))
+      setError(nextError)
+      throw nextError
+    } finally {
+      setIsFetching(false)
+    }
+  }, [client, stableKey, staleTime])
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    setIsFetching(true)
+    setError(null)
+    client.fetchQuery(stableKey, queryFnRef.current, staleTime)
+      .then((result) => {
+        if (!cancelled) setData(result)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err : new Error(String(err)))
+      })
+      .finally(() => {
+        if (!cancelled) setIsFetching(false)
+      })
+    return () => { cancelled = true }
+  }, [client, enabled, keyString, stableKey, staleTime])
+
+  return {
+    data,
+    error,
+    isLoading: enabled && data === undefined && isFetching,
+    isFetching,
+    isError: error !== null,
+    isSuccess: data !== undefined && error === null,
+    refetch: () => execute(true),
+  }
+}
+
+export function useApiMutation<TData, TVariables>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  options?: { invalidate?: QueryKey[]; onSuccess?: (data: TData, variables: TVariables) => void }
+): MutationState<TData, TVariables> {
+  const client = useQueryClient()
+  const [data, setData] = useState<TData | undefined>()
+  const [error, setError] = useState<Error | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  const mutate = useCallback(async (variables: TVariables) => {
+    setIsPending(true)
+    setError(null)
+    try {
+      const result = await mutationFn(variables)
+      setData(result)
+      for (const key of options?.invalidate ?? []) client.invalidateQueries(key)
+      options?.onSuccess?.(result, variables)
+      return result
+    } catch (err) {
+      const nextError = err instanceof Error ? err : new Error(String(err))
+      setError(nextError)
+      throw nextError
+    } finally {
+      setIsPending(false)
+    }
+  }, [client, mutationFn, options])
+
+  return { data, error, isPending, mutate }
+}

--- a/src/api/services.ts
+++ b/src/api/services.ts
@@ -1,0 +1,75 @@
+import {
+  getCall,
+  getCallFrequencies,
+  getCalls,
+  getCallTranscription,
+  getCallTransmissions,
+  getSystems,
+  getTalkgroups,
+  type CallQueryParams,
+  type TalkgroupQueryParams,
+} from '@/api/client'
+import type {
+  Call,
+  CallFrequency,
+  CallListResponse,
+  CallTransmission,
+  SystemListResponse,
+  TalkgroupListResponse,
+  Transcription,
+} from '@/api/types'
+import type { QueryKey } from '@/api/query'
+
+export const queryKeys = {
+  all: ['api'] as const,
+  systems: {
+    all: ['api', 'systems'] as const,
+    list: () => ['api', 'systems', 'list'] as const,
+  },
+  talkgroups: {
+    all: ['api', 'talkgroups'] as const,
+    list: (params?: TalkgroupQueryParams) => ['api', 'talkgroups', 'list', params ?? {}] as const,
+  },
+  calls: {
+    all: ['api', 'calls'] as const,
+    list: (params?: CallQueryParams) => ['api', 'calls', 'list', params ?? {}] as const,
+    detail: (id: number) => ['api', 'calls', 'detail', id] as const,
+    related: (id: number) => ['api', 'calls', 'detail', id, 'related'] as const,
+  },
+} satisfies Record<string, unknown>
+
+export interface CallDetailData {
+  call: Call
+  transmissions: CallTransmission[]
+  frequencies: CallFrequency[]
+  transcription: Transcription | null
+}
+
+export const systemService = {
+  list: (): Promise<SystemListResponse> => getSystems(),
+}
+
+export const talkgroupService = {
+  list: (params?: TalkgroupQueryParams): Promise<TalkgroupListResponse> => getTalkgroups(params),
+}
+
+export const callService = {
+  list: (params?: CallQueryParams): Promise<CallListResponse> => getCalls(params),
+  get: (id: number): Promise<Call> => getCall(id),
+  getDetail: async (id: number): Promise<CallDetailData> => {
+    const call = await getCall(id)
+    const transmissions = call.src_list && call.src_list.length > 0
+      ? call.src_list
+      : await getCallTransmissions(id).then((res) => res.transmissions || []).catch(() => [])
+    const frequencies = call.freq_list && call.freq_list.length > 0
+      ? call.freq_list
+      : await getCallFrequencies(id).then((res) => res.frequencies || []).catch(() => [])
+    const transcription = await getCallTranscription(id).catch(() => null)
+
+    return { call, transmissions, frequencies, transcription }
+  },
+}
+
+export function invalidateCallQueries(id?: number): QueryKey[] {
+  return id ? [queryKeys.calls.all, queryKeys.calls.detail(id)] : [queryKeys.calls.all]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { registerSW } from 'virtual:pwa-register'
 import { setUpdateSW } from './hooks/usePWAUpdate'
+import { QueryProvider } from './api/query'
 import App from './App'
 import './index.css'
 
@@ -26,8 +27,10 @@ if ('serviceWorker' in navigator) {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryProvider>
   </StrictMode>
 )

--- a/src/pages/CallDetail.tsx
+++ b/src/pages/CallDetail.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { useAudioStore, selectIsPlaying } from '@/stores/useAudioStore'
-import { getCall, getCallTransmissions, getCallFrequencies, getCallTranscription, getCachedSystemType } from '@/api/client'
-import type { Call, CallTransmission, CallFrequency, Transcription } from '@/api/types'
+import { getCachedSystemType } from '@/api/client'
+import { useApiQuery } from '@/api/query'
+import { callService, queryKeys } from '@/api/services'
 import {
   formatDuration,
   formatDateTime,
@@ -24,84 +25,23 @@ import { TRANSMISSION_COLORS } from '@/components/audio/TransmissionTimeline'
 
 export default function CallDetail() {
   const { id } = useParams<{ id: string }>()
-  const [call, setCall] = useState<Call | null>(null)
-  const [transmissions, setTransmissions] = useState<CallTransmission[]>([])
-  const [frequencies, setFrequencies] = useState<CallFrequency[]>([])
-  const [transcription, setTranscription] = useState<Transcription | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
   const unitIdHex = useFilterStore((s) => s.unitIdHex)
   const loadCall = useAudioStore((s) => s.loadCall)
   const currentCall = useAudioStore((s) => s.currentCall)
   const isPlaying = useAudioStore(selectIsPlaying)
 
   const callId = id ? parseInt(id, 10) : NaN
-
-  useEffect(() => {
-    if (isNaN(callId)) return
-
-    let cancelled = false
-
-    setLoading(true)
-    setError(null)
-    setCall(null)
-    setTransmissions([])
-    setFrequencies([])
-    setTranscription(null)
-
-    getCall(callId)
-      .then(async (callRes) => {
-        if (cancelled) return
-        setCall(callRes)
-
-        // Use inline src_list if present, otherwise fetch
-        if (callRes.src_list && callRes.src_list.length > 0) {
-          setTransmissions(callRes.src_list)
-        } else {
-          try {
-            const txRes = await getCallTransmissions(callId)
-            if (!cancelled) setTransmissions(txRes.transmissions || [])
-          } catch {
-            // No transmissions available
-          }
-        }
-
-        if (cancelled) return
-
-        // Use inline freq_list if present, otherwise fetch
-        if (callRes.freq_list && callRes.freq_list.length > 0) {
-          setFrequencies(callRes.freq_list)
-        } else {
-          try {
-            const freqRes = await getCallFrequencies(callId)
-            if (!cancelled) setFrequencies(freqRes.frequencies || [])
-          } catch {
-            // No frequencies available
-          }
-        }
-
-        if (cancelled) return
-
-        // Fetch transcription
-        try {
-          const tx = await getCallTranscription(callId)
-          if (!cancelled) setTranscription(tx)
-        } catch {
-          // Transcription not available
-        }
-      })
-      .catch((err) => {
-        if (cancelled) return
-        console.error(err)
-        setError('Failed to load call details')
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-
-    return () => { cancelled = true }
-  }, [callId])
+  const detailQuery = useApiQuery(
+    queryKeys.calls.detail(callId),
+    () => callService.getDetail(callId),
+    { enabled: !isNaN(callId), staleTime: 30_000 }
+  )
+  const call = detailQuery.data?.call ?? null
+  const transmissions = detailQuery.data?.transmissions ?? []
+  const frequencies = detailQuery.data?.frequencies ?? []
+  const transcription = detailQuery.data?.transcription ?? null
+  const loading = detailQuery.isLoading
+  const error = detailQuery.error ? 'Failed to load call details' : null
 
   const tgid = call?.tgid ?? 0
   const tgAlphaTag = call?.tg_alpha_tag

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useCallback, useMemo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SkeletonRow } from '@/components/ui/skeleton'
@@ -7,22 +7,18 @@ import { Badge } from '@/components/ui/badge'
 import { Pagination } from '@/components/ui/pagination'
 import { CallList } from '@/components/calls/CallList'
 import { TalkgroupMultiSelect } from '@/components/calls/TalkgroupMultiSelect'
-import { getCalls, getTalkgroups, getSystems } from '@/api/client'
+import { getCalls } from '@/api/client'
+import { useApiQuery } from '@/api/query'
+import { callService, queryKeys, systemService, talkgroupService } from '@/api/services'
 import { getSystemTypeLabel } from '@/lib/utils'
 import { useRealtimeStore } from '@/stores/useRealtimeStore'
 import { useTranscriptionCache } from '@/stores/useTranscriptionCache'
-import type { Call, Talkgroup, System } from '@/api/types'
+import type { CallQueryParams } from '@/api/client'
 
 const DEFAULT_PAGE_SIZE = 50
 
 export default function Calls() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [calls, setCalls] = useState<Call[]>([])
-  const [loading, setLoading] = useState(true)
-  const [totalCount, setTotalCount] = useState(0)
-  const [systems, setSystems] = useState<System[]>([])
-  const [talkgroups, setTalkgroups] = useState<Talkgroup[]>([])
-
   const page = parseInt(searchParams.get('page') || '1', 10)
   const pageSize = parseInt(searchParams.get('size') || String(DEFAULT_PAGE_SIZE), 10)
   const systemFilter = searchParams.get('system') || ''
@@ -43,16 +39,6 @@ export default function Calls() {
     if (!talkgroupFilterRaw) return []
     return talkgroupFilterRaw.split(',').filter(Boolean)
   }, [talkgroupFilterRaw])
-
-  // Fetch systems and talkgroups for filters
-  useEffect(() => {
-    Promise.all([getSystems(), getTalkgroups({ limit: 100 })])
-      .then(([sysRes, tgRes]) => {
-        setSystems(sysRes.systems || [])
-        setTalkgroups(tgRes.talkgroups || [])
-      })
-      .catch(console.error)
-  }, [])
 
   const fetchTranscription = useTranscriptionCache((s) => s.fetchTranscription)
 
@@ -92,10 +78,18 @@ export default function Calls() {
     return { start_time: start.toISOString(), end_time: end.toISOString() }
   }, [aroundTime])
 
-  // Fetch calls
-  useEffect(() => {
-    setLoading(true)
-    getCalls({
+  const systemsQuery = useApiQuery(
+    queryKeys.systems.list(),
+    systemService.list,
+    { staleTime: 5 * 60 * 1000 }
+  )
+  const talkgroupsQuery = useApiQuery(
+    queryKeys.talkgroups.list({ limit: 100 }),
+    () => talkgroupService.list({ limit: 100 }),
+    { staleTime: 5 * 60 * 1000 }
+  )
+
+  const callParams = useMemo<CallQueryParams>(() => ({
       system_id: tgFilterSystemId || systemFilter || undefined,
       tgid: tgFilterTgid,
       sort: '-start_time',
@@ -104,20 +98,27 @@ export default function Calls() {
       end_time: timeWindow?.end_time,
       limit: pageSize,
       offset,
-    })
-      .then((res) => {
-        const fetched = res.calls || []
-        setCalls(fetched)
-        setTotalCount(res.total)
-        for (const call of fetched) {
-          if (call.has_transcription) {
-            fetchTranscription(call.call_id)
-          }
-        }
-      })
-      .catch(console.error)
-      .finally(() => setLoading(false))
-  }, [page, pageSize, systemFilter, tgFilterSystemId, tgFilterTgid, offset, fetchTranscription, timeWindow])
+    }), [tgFilterSystemId, systemFilter, tgFilterTgid, timeWindow, pageSize, offset])
+
+  const callsQuery = useApiQuery(
+    queryKeys.calls.list(callParams),
+    () => callService.list(callParams),
+    { staleTime: 10_000 }
+  )
+
+  const systems = systemsQuery.data?.systems || []
+  const talkgroups = talkgroupsQuery.data?.talkgroups || []
+  const calls = callsQuery.data?.calls || []
+  const totalCount = callsQuery.data?.total || 0
+  const loading = callsQuery.isLoading
+
+  useEffect(() => {
+    for (const call of calls) {
+      if (call.has_transcription) {
+        fetchTranscription(call.call_id)
+      }
+    }
+  }, [calls, fetchTranscription])
 
   // Auto-navigate to the page containing the highlighted call
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add a first-party query provider with typed read and mutation hooks, cache keys, stale-time handling, invalidation, and request de-duplication.
- Add dashboard data-query documentation covering reads, writes, pagination, refresh, errors, and the Zustand boundary.
- Migrate Calls and CallDetail to the standardized data layer as representative list/detail pages.

## Verification
- npm run build