### PR TITLE
docs: align auth, dev proxy, routes, and API paths with current app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This file provides guidance to Codex and other coding agents when working with c
 
 ### Backend
 
-tr-engine aggregates data from trunk-recorder radio systems. API documentation lives in `../tr-engine/docs/` (swagger at `/swagger/`, markdown in `docs/api/`).
+tr-engine aggregates data from trunk-recorder radio systems. Source of truth for the API is `../tr-engine/openapi.yaml` (Swagger UI on the engine at `/docs.html`).
 
 ## Development Commands
 
@@ -27,9 +27,9 @@ npm run lint          # Type-check only (tsc --noEmit)
 npm run api:generate  # Regenerate TypeScript types from OpenAPI spec
 ```
 
-There are no tests configured in this project. The `lint` command is the primary code quality check.
+There is no automated unit-test suite yet (`TODO.md` tracks vitest). `npm run lint` / `npm run build` are the primary quality checks. See `docs/quality-gates.md`.
 
-Vite proxies `/api` to `https://tr-api.luxprimatech.com` and `/api/events` to the SSE endpoint in dev mode.
+Dev proxy: set `TR_ENGINE_URL` in `.env` (e.g. `http://localhost:8080`). Vite then proxies `/api` and `/health` to that origin. Optional `TR_AUTH_TOKEN` injects a static bearer for token-mode engines.
 
 ## Tech Stack
 
@@ -81,38 +81,58 @@ src/
 
 ### Routing
 
-React Router v7 with all routes nested under `MainLayout` (provides sidebar, header, audio player):
+React Router v7. `/login` is public; all other routes sit under `RequireAuth` + `MainLayout` (sidebar, header, audio player). Lazy-loaded pages are wrapped in `ErrorBoundary`.
 
 ```
+/login               → Login (full auth mode)
 /                    → Dashboard (live monitoring + recent calls)
 /calls               → Call history browser
 /calls/:id           → Call detail with transmissions/audio
+/transcriptions      → Transcription search
 /talkgroups          → Talkgroup list
 /talkgroups/:id      → Talkgroup detail
+/talkgroups/:id/analytics → Talkgroup analytics
 /units               → Unit list
 /units/:id           → Unit detail
+/systems             → Recorders / systems overview
+/systems/:id         → System detail
 /affiliations        → Live unit-talkgroup affiliation status
 /directory           → Reference talkgroup directory browser
-/settings            → Color rules, favorites, display preferences
-/admin               → System merge, metadata editing, CSV import
+/call-groups         → Call groups browser
+/call-groups/:id     → Call group detail
+/investigate         → Investigate timeline
+/settings            → Colors, favorites, write token, display prefs
+/admin               → System merge, maintenance, CSV import
+/users               → User management (full auth / admin)
 ```
 
 ### API Layer (`src/api/`)
 
-- `client.ts`: Typed REST functions organized by domain (Systems, Talkgroups, Units, Calls, Affiliations, Admin). Base URL `/api/v1`. Uses `fetch` with a `request<T>()` wrapper.
+- `client.ts`: Typed REST functions + `request<T>()` wrapper. Base URL `/api/v1`. Injects JWT, legacy write token, or auth-init `read_token` as `Authorization: Bearer`.
+- `auth-init.ts`: Calls `GET /api/v1/auth-init` on load; drives open / token / full mode via `useAuthStore`.
 - `types.ts`: Hand-written types for API responses and SSE events.
-- `generated.ts`: Auto-generated from OpenAPI spec via `npm run api:generate`. Referenced by `types.ts`.
-- `eventsource.ts`: Singleton `SSEManager` using the `EventSource` API. Connects to `/api/events`. Auto-reconnect with exponential backoff. Typed event handlers for `call_start`, `call_update`, `call_end`, `unit_event`, `recorder_update`, `rate_update`. Methods: `connect()`, `disconnect()`, `reconnect()`.
+- `generated.ts`: Auto-generated from OpenAPI via `npm run api:generate`.
+- `eventsource.ts`: Singleton `SSEManager` → `GET /api/v1/events/stream`. Auto-reconnect with backoff. Handlers for `call_start`, `call_end`, `unit_event`, `recorder_update`, `rate_update`, etc. (`call_update` remains typed for compatibility but tr-engine currently does not emit it.)
+
+### Auth (`useAuthStore`)
+
+State machine: `idle → detecting → open | token | login-required | authenticated | error`.
+
+- **open** — no credentials; `canWrite()` true
+- **token** — shared bearer (proxy or stored token)
+- **full** — JWT login; write if role is editor/admin or legacy write token present
 
 ### State Management (Zustand Stores)
 
 | Store | File | Purpose | Persisted |
 |-------|------|---------|-----------|
-| `useRealtimeStore` | `stores/useRealtimeStore.ts` | SSE events, active calls `Map<number, Call>`, decode rates, recorders | No |
-| `useAudioStore` | `stores/useAudioStore.ts` | Playback state machine, queue, transmissions, history | No |
-| `useMonitorStore` | `stores/useMonitorStore.ts` | Monitored talkgroups `Set<system_id:tgid>`, monitoring toggle | localStorage |
-| `useTalkgroupColors` | `stores/useTalkgroupColors.ts` | Color rules, per-talkgroup overrides, hide/highlight modes | localStorage |
-| `useFilterStore` | `stores/useFilterStore.ts` | Selected systems, favorite talkgroups, search, time range | localStorage |
+| `useAuthStore` | `stores/useAuthStore.ts` | Auth mode, JWT, read/write tokens | writeToken only |
+| `useRealtimeStore` | `stores/useRealtimeStore.ts` | SSE events, active calls, decode rates, recorders | No |
+| `useAudioStore` | `stores/useAudioStore.ts` | Playback state machine, queue, transmissions | No |
+| `useMonitorStore` | `stores/useMonitorStore.ts` | Monitored talkgroups, monitoring toggle | localStorage |
+| `useTalkgroupColors` | `stores/useTalkgroupColors.ts` | Color rules, overrides, hide/highlight | localStorage |
+| `useFilterStore` | `stores/useFilterStore.ts` | Systems, favorites, search, time range | localStorage |
+| `useThemeStore` / alerts / toasts / etc. | `stores/*` | UI chrome and secondary features | varies |
 
 ### Key Architectural Patterns
 
@@ -175,28 +195,28 @@ Understanding the P25 trunked radio hierarchy is essential for this codebase:
 | butco | 340 | 4 | 1 | 1 |
 | warco | 34D | 1 | 13 | 17 |
 
-## API Conventions (tr-engine v0.7.3)
+## API Conventions (tr-engine)
 
-**REST + SSE Pattern:**
-- REST API (`/api/v1`) for CRUD operations and queries
-- SSE API (`/api/events`) for real-time event streaming
+**REST + SSE:**
+- REST under `/api/v1` for CRUD and queries
+- SSE at `/api/v1/events/stream` (not `/api/events`)
 
-**Key Endpoints:**
-- `GET /api/v1/systems` → `{systems: [...], count}` — logical systems
-- `GET /api/v1/talkgroups` → `{talkgroups: [...], total}`
-- `GET /api/v1/units` → `{units: [...], total}`
-- `GET /api/v1/calls` → `{calls: [...], total}`
-- `GET /api/v1/calls/:id` → `Call` with inline `src_list`, `freq_list`, `units`
-- `GET /api/v1/affiliations` → `{affiliations: [...], total, summary}`
-- `GET /api/v1/talkgroup-directory` → `{talkgroups: [...], total}`
-- `POST /api/v1/admin/merge-systems` → `SystemMergeResponse`
-- `PATCH /api/v1/talkgroups/:id` → Update talkgroup metadata
-- `PATCH /api/v1/units/:id` → Update unit metadata
-- `POST /api/v1/systems/:id/import-directory` → CSV talkgroup import
+**Auth discovery:** `GET /api/v1/auth-init` → `{ mode: open|token|full, read_token?, jwt_enabled }`
 
-**Data Conventions:**
-- Frequencies stored in Hz (not MHz)
-- Timestamps in ISO 8601 RFC3339 UTC format
+**Key endpoints (non-exhaustive):**
+- `GET /api/v1/systems`, `/talkgroups`, `/units`, `/calls`, `/affiliations`
+- `GET /api/v1/calls/:id` — call with inline `src_list` / `freq_list` when available
+- `GET /api/v1/transcriptions/search` — full-text transcription search
+- `GET /api/v1/talkgroup-directory`
+- `PATCH /api/v1/talkgroups/:id`, `PATCH /api/v1/units/:id`
+- `POST /api/v1/admin/systems/merge`, maintenance endpoints under `/api/v1/admin/*`
+
+Regenerate client types after engine OpenAPI changes: `npm run api:generate` (expects `../tr-engine/openapi.yaml`).
+
+**Data conventions:**
+- Frequencies in Hz (not MHz)
+- Timestamps ISO 8601 RFC3339 UTC
+- Composite keys `"system_id:tgid"` / `"system_id:unit_id"` in the UI
 - Pagination: `limit` (max 1000, default 50) + `offset`, response uses `total` field
 - Composite keys: `system_id:tgid` format (integer system_id)
 - Calls include inline `src_list` (transmissions), `freq_list` (frequencies), `units` (participating units)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Prefer AGENTS.md for active agent instructions when both exist; keep them in sync.
+
 
 ## Project Overview
 
@@ -15,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Backend
 
-tr-engine aggregates data from trunk-recorder radio systems. API documentation lives in `../tr-engine/docs/` (swagger at `/swagger/`, markdown in `docs/api/`).
+tr-engine aggregates data from trunk-recorder radio systems. Source of truth for the API is `../tr-engine/openapi.yaml` (Swagger UI on the engine at `/docs.html`).
 
 ## Development Commands
 
@@ -24,12 +25,12 @@ npm install           # Install dependencies
 npm run dev           # Start dev server on 0.0.0.0:5173
 npm run build         # Type-check (tsc -b) then build with Vite
 npm run lint          # Type-check only (tsc --noEmit)
-npm run api:generate  # Regenerate TypeScript types from ../tr-engine/openapi.yaml
+npm run api:generate  # Regenerate TypeScript types from OpenAPI spec
 ```
 
-There are no tests configured in this project. The `lint` command is the primary code quality check.
+There is no automated unit-test suite yet (`TODO.md` tracks vitest). `npm run lint` / `npm run build` are the primary quality checks. See `docs/quality-gates.md`.
 
-Vite proxies `/api` to `https://tr-api.luxprimatech.com` and `/api/events` to the SSE endpoint in dev mode.
+Dev proxy: set `TR_ENGINE_URL` in `.env` (e.g. `http://localhost:8080`). Vite then proxies `/api` and `/health` to that origin. Optional `TR_AUTH_TOKEN` injects a static bearer for token-mode engines.
 
 ## Tech Stack
 
@@ -81,38 +82,58 @@ src/
 
 ### Routing
 
-React Router v7 with all routes nested under `MainLayout` (provides sidebar, header, audio player):
+React Router v7. `/login` is public; all other routes sit under `RequireAuth` + `MainLayout` (sidebar, header, audio player). Lazy-loaded pages are wrapped in `ErrorBoundary`.
 
 ```
+/login               → Login (full auth mode)
 /                    → Dashboard (live monitoring + recent calls)
 /calls               → Call history browser
 /calls/:id           → Call detail with transmissions/audio
+/transcriptions      → Transcription search
 /talkgroups          → Talkgroup list
 /talkgroups/:id      → Talkgroup detail
+/talkgroups/:id/analytics → Talkgroup analytics
 /units               → Unit list
 /units/:id           → Unit detail
+/systems             → Recorders / systems overview
+/systems/:id         → System detail
 /affiliations        → Live unit-talkgroup affiliation status
 /directory           → Reference talkgroup directory browser
-/settings            → Color rules, favorites, display preferences
-/admin               → System merge, metadata editing, CSV import
+/call-groups         → Call groups browser
+/call-groups/:id     → Call group detail
+/investigate         → Investigate timeline
+/settings            → Colors, favorites, write token, display prefs
+/admin               → System merge, maintenance, CSV import
+/users               → User management (full auth / admin)
 ```
 
 ### API Layer (`src/api/`)
 
-- `client.ts`: Typed REST functions organized by domain (Systems, Talkgroups, Units, Calls, Affiliations, Admin). Base URL `/api/v1`. Uses `fetch` with a `request<T>()` wrapper.
+- `client.ts`: Typed REST functions + `request<T>()` wrapper. Base URL `/api/v1`. Injects JWT, legacy write token, or auth-init `read_token` as `Authorization: Bearer`.
+- `auth-init.ts`: Calls `GET /api/v1/auth-init` on load; drives open / token / full mode via `useAuthStore`.
 - `types.ts`: Hand-written types for API responses and SSE events.
-- `generated.ts`: Auto-generated from OpenAPI spec via `npm run api:generate`. Referenced by `types.ts`.
-- `eventsource.ts`: Singleton `SSEManager` using the `EventSource` API. Connects to `/api/events`. Auto-reconnect with exponential backoff. Typed event handlers for `call_start`, `call_update`, `call_end`, `unit_event`, `recorder_update`, `rate_update`. Methods: `connect()`, `disconnect()`, `reconnect()`.
+- `generated.ts`: Auto-generated from OpenAPI via `npm run api:generate`.
+- `eventsource.ts`: Singleton `SSEManager` → `GET /api/v1/events/stream`. Auto-reconnect with backoff. Handlers for `call_start`, `call_end`, `unit_event`, `recorder_update`, `rate_update`, etc. (`call_update` remains typed for compatibility but tr-engine currently does not emit it.)
+
+### Auth (`useAuthStore`)
+
+State machine: `idle → detecting → open | token | login-required | authenticated | error`.
+
+- **open** — no credentials; `canWrite()` true
+- **token** — shared bearer (proxy or stored token)
+- **full** — JWT login; write if role is editor/admin or legacy write token present
 
 ### State Management (Zustand Stores)
 
 | Store | File | Purpose | Persisted |
 |-------|------|---------|-----------|
-| `useRealtimeStore` | `stores/useRealtimeStore.ts` | SSE events, active calls `Map<number, Call>`, decode rates, recorders | No |
-| `useAudioStore` | `stores/useAudioStore.ts` | Playback state machine, queue, transmissions, history | No |
-| `useMonitorStore` | `stores/useMonitorStore.ts` | Monitored talkgroups `Set<system_id:tgid>`, monitoring toggle | localStorage |
-| `useTalkgroupColors` | `stores/useTalkgroupColors.ts` | Color rules, per-talkgroup overrides, hide/highlight modes | localStorage |
-| `useFilterStore` | `stores/useFilterStore.ts` | Selected systems, favorite talkgroups, search, time range | localStorage |
+| `useAuthStore` | `stores/useAuthStore.ts` | Auth mode, JWT, read/write tokens | writeToken only |
+| `useRealtimeStore` | `stores/useRealtimeStore.ts` | SSE events, active calls, decode rates, recorders | No |
+| `useAudioStore` | `stores/useAudioStore.ts` | Playback state machine, queue, transmissions | No |
+| `useMonitorStore` | `stores/useMonitorStore.ts` | Monitored talkgroups, monitoring toggle | localStorage |
+| `useTalkgroupColors` | `stores/useTalkgroupColors.ts` | Color rules, overrides, hide/highlight | localStorage |
+| `useFilterStore` | `stores/useFilterStore.ts` | Systems, favorites, search, time range | localStorage |
+| `useThemeStore` / alerts / toasts / etc. | `stores/*` | UI chrome and secondary features | varies |
 
 ### Key Architectural Patterns
 
@@ -175,28 +196,28 @@ Understanding the P25 trunked radio hierarchy is essential for this codebase:
 | butco | 340 | 4 | 1 | 1 |
 | warco | 34D | 1 | 13 | 17 |
 
-## API Conventions (tr-engine v0.7.3)
+## API Conventions (tr-engine)
 
-**REST + SSE Pattern:**
-- REST API (`/api/v1`) for CRUD operations and queries
-- SSE API (`/api/events`) for real-time event streaming
+**REST + SSE:**
+- REST under `/api/v1` for CRUD and queries
+- SSE at `/api/v1/events/stream` (not `/api/events`)
 
-**Key Endpoints:**
-- `GET /api/v1/systems` → `{systems: [...], count}` — logical systems
-- `GET /api/v1/talkgroups` → `{talkgroups: [...], total}`
-- `GET /api/v1/units` → `{units: [...], total}`
-- `GET /api/v1/calls` → `{calls: [...], total}`
-- `GET /api/v1/calls/:id` → `Call` with inline `src_list`, `freq_list`, `units`
-- `GET /api/v1/affiliations` → `{affiliations: [...], total, summary}`
-- `GET /api/v1/talkgroup-directory` → `{talkgroups: [...], total}`
-- `POST /api/v1/admin/merge-systems` → `SystemMergeResponse`
-- `PATCH /api/v1/talkgroups/:id` → Update talkgroup metadata
-- `PATCH /api/v1/units/:id` → Update unit metadata
-- `POST /api/v1/systems/:id/import-directory` → CSV talkgroup import
+**Auth discovery:** `GET /api/v1/auth-init` → `{ mode: open|token|full, read_token?, jwt_enabled }`
 
-**Data Conventions:**
-- Frequencies stored in Hz (not MHz)
-- Timestamps in ISO 8601 RFC3339 UTC format
+**Key endpoints (non-exhaustive):**
+- `GET /api/v1/systems`, `/talkgroups`, `/units`, `/calls`, `/affiliations`
+- `GET /api/v1/calls/:id` — call with inline `src_list` / `freq_list` when available
+- `GET /api/v1/transcriptions/search` — full-text transcription search
+- `GET /api/v1/talkgroup-directory`
+- `PATCH /api/v1/talkgroups/:id`, `PATCH /api/v1/units/:id`
+- `POST /api/v1/admin/systems/merge`, maintenance endpoints under `/api/v1/admin/*`
+
+Regenerate client types after engine OpenAPI changes: `npm run api:generate` (expects `../tr-engine/openapi.yaml`).
+
+**Data conventions:**
+- Frequencies in Hz (not MHz)
+- Timestamps ISO 8601 RFC3339 UTC
+- Composite keys `"system_id:tgid"` / `"system_id:unit_id"` in the UI
 - Pagination: `limit` (max 1000, default 50) + `offset`, response uses `total` field
 - Composite keys: `system_id:tgid` format (integer system_id)
 - Calls include inline `src_list` (transmissions), `freq_list` (frequencies), `units` (participating units)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ services:
       - "3000:3000"
 ```
 
-Then configure your proxy to route `/api/*`, `/audio/*`, and `/health/*` to tr-engine and everything else to `tr-dashboard:3000`. The key requirement is that `/api/events` (SSE) must have `flush_interval -1` or equivalent to avoid buffering.
+Then configure your proxy to route `/api/*`, `/audio/*`, and `/health/*` to tr-engine and everything else to `tr-dashboard:3000`. SSE is at `/api/v1/events/stream` — disable proxy buffering (`flush_interval -1` in Caddy, `proxy_buffering off` in nginx).
 
 ### Migrating from v0.9.x (Caddy-based image)
 
@@ -155,14 +155,17 @@ npm install
 
 ### Configure
 
-The dev server proxies API requests to tr-engine. If your backend requires authentication, create a `.env` file:
+Create a `.env` so the Vite dev server can proxy API requests to tr-engine:
 
 ```bash
 # .env
-TR_AUTH_TOKEN=your-auth-token-here
+TR_ENGINE_URL=http://localhost:8080   # required for /api and /health proxy
+# TR_AUTH_TOKEN=...                   # optional: inject bearer for token-mode backends
 ```
 
-The proxy target is configured in `vite.config.ts` (default: `https://tr-engine.luxprimatech.com`). Change this to point at your own tr-engine instance.
+Without `TR_ENGINE_URL`, the dev server does **not** proxy API calls (you will get 404s on `/api/*`).
+
+In **full** auth mode (engine has `ADMIN_PASSWORD`), leave `TR_AUTH_TOKEN` unset and use the dashboard login page. In **token** mode, either set `TR_AUTH_TOKEN` for the proxy or enter the token via the UI/Settings flow your engine expects. In **open** mode, no token is needed.
 
 ### Run
 
@@ -170,7 +173,7 @@ The proxy target is configured in `vite.config.ts` (default: `https://tr-engine.
 npm run dev
 ```
 
-Runs on `http://localhost:5173` with API proxy to the tr-engine backend.
+Runs on `http://localhost:5173` with `/api` and `/health` proxied to `TR_ENGINE_URL`.
 
 ### Build
 
@@ -184,27 +187,35 @@ npm run api:generate # Regenerate API types from OpenAPI spec
 
 Before marking implementation work complete, follow the project quality gates in [`docs/quality-gates.md`](docs/quality-gates.md).
 
-## Write Access
+## Authentication & Write Access
 
-tr-dashboard supports inline editing of talkgroup metadata (name, group, tag, priority, description) and unit names directly from their detail pages.
+The dashboard discovers auth requirements from tr-engine's `GET /api/v1/auth-init` (no Caddy token injection required).
 
-### How it works
+| Engine config | Mode | Dashboard behavior |
+|---------------|------|--------------------|
+| Neither `AUTH_TOKEN` nor `ADMIN_PASSWORD` | **open** | No login; all users can write |
+| `AUTH_TOKEN` only | **token** | Shared bearer token; configure proxy and/or Settings |
+| `ADMIN_PASSWORD` set | **full** | Login page for JWT (roles: viewer/editor/admin). Optional `AUTH_TOKEN` becomes a guest **read** token from auth-init |
 
-- If your tr-engine has no `WRITE_TOKEN` configured, editing works for everyone automatically.
-- If `WRITE_TOKEN` is set, users need to enter it in **Settings → Write Access** to enable editing. The token is stored in the browser's localStorage.
-- Without a valid write token, the Edit button still appears but saves will show an error message directing users to Settings.
+### Write access
+
+- **open** — edits allowed without credentials.
+- **full** — editors and admins can write after login. Viewers are read-only unless they still have a legacy write token saved in Settings.
+- **Legacy `WRITE_TOKEN`** — still accepted by tr-engine during deprecation. Users can store it under **Settings → Write Access** (localStorage). Prefer JWT roles or `tre_...` API keys for new deployments.
 
 ### Reverse proxy setup
 
-If you run tr-dashboard behind a reverse proxy that injects an auth token, make sure it **doesn't overwrite** the `Authorization` header when the browser sends one. The dashboard sends the write token as `Authorization: Bearer <token>` on write requests (PATCH/POST/PUT/DELETE).
+If your proxy injects a public read token, **do not overwrite** a browser-sent `Authorization` header (JWT login, user-entered token, or API key). Prefer conditional injection.
 
-**Caddy example** — use conditional injection so the read token is only added when the browser doesn't send its own:
+**Caddy example** (tr-engine listens on **8080**):
 
 ```caddyfile
 handle /api/* {
     @no_auth not header Authorization *
     request_header @no_auth Authorization "Bearer {$TR_AUTH_TOKEN}"
-    reverse_proxy tr-engine:8000
+    reverse_proxy tr-engine:8080 {
+        flush_interval -1
+    }
 }
 ```
 
@@ -218,7 +229,8 @@ location /api/ {
         set $auth $http_authorization;
     }
     proxy_set_header Authorization $auth;
-    proxy_pass http://tr-engine:8000;
+    proxy_pass http://tr-engine:8080;
+    proxy_buffering off;  # required for SSE /api/v1/events/stream
 }
 ```
 


### PR DESCRIPTION
## Summary
Documentation accuracy pass for tr-dashboard.

### Fixes
- **Auth / write access:** describe open / token / full via `auth-init`; demote legacy WRITE_TOKEN
- **Dev setup:** document required `TR_ENGINE_URL` (proxy is not hardcoded to luxprimatech)
- **Proxy examples:** tr-engine port **8080** (was 8000); SSE path `/api/v1/events/stream`
- **AGENTS.md / CLAUDE.md:** full route list, auth store, SSE path, current stores

## Test plan
- [x] Docs reviewed against `useAuthStore`, `vite.config.ts`, `App.tsx`, `eventsource.ts`
- [ ] Skim README Quick Start + Write Access after merge